### PR TITLE
feat: Claude Code hooks による作業ログ自動化 + InsightLog インポート

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -9,6 +9,7 @@ Claude Code の hooks を「タイムカード」として使い、作業イベ�
 - **失敗してもツール実行をブロックしない**。フックスクリプトは常に `exit 0`。
 - **プロジェクト内 `.claude/settings.json` で配線**。ユーザー設定 (`~/.claude/settings.json`) は触らない。
 - **イベントには必ず `repo`（git toplevel）と `repo_remote`（origin URL）を載せる**。横断集計の主キー。
+- **クロスプラットフォーム**: 日付/時刻計算は GNU date 依存ではなく **jq の `now` / `fromdateiso8601` / `gmtime`** で統一実装。macOS (BSD date) でも同じ精度で動く。Windows はネイティブ shell では走らないが、WSL / Git Bash 内なら動く。
 
 ## 出力先の解決順
 

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -22,9 +22,10 @@ Claude Code の hooks を「タイムカード」として使い、作業イベ�
 
 ```
 .claude/hooks/
-  autolog-common.sh         # 共通: 出力先解決・タイムスタンプ・JSONL 追記・git 情報取得
+  autolog-common.sh         # 共通: 出力先解決・タイムスタンプ・JSONL 追記・git 情報・transcript 集計
   autolog-session-start.sh  # SessionStart 用
-  autolog-stop.sh           # Stop 用（毎ターン累積メトリクス）
+  autolog-stop.sh           # Stop 用（毎ターン、transcript ベースの累積メトリクス）
+  autolog-session-end.sh    # SessionEnd 用（end_reason 付き最終スナップショット）
   autolog-posttool.sh       # PostToolUse(Bash) 用、git 系コマンドを検出
   autolog-daily-report.sh   # 日次サマリーを Markdown で標準出力
   README.md                 # 本ファイル
@@ -32,7 +33,7 @@ Claude Code の hooks を「タイムカード」として使い、作業イベ�
 $HOME/.claude/tmp/autolog/      # 既定の出力先（または INSIGHTLOG_AUTOLOG_DIR）
   events.jsonl                  # メインのイベントログ（全リポ集約・追記専用）
   sessions/
-    <session_id>.start          # 開始 ts 保存。Stop hook の duration fallback に使う
+    <session_id>.start          # 開始 ts 保存。transcript が読めない時の duration fallback
 ```
 
 ## イベントスキーマ
@@ -67,15 +68,34 @@ git リポでないディレクトリで実行された場合は `repo` / `branc
 
 Claude Code の `Stop` フックは **毎ターン終了時に発火する**（セッション終了時だけではない）。なので各行は「そのターン終了時点の累積値スナップショット」として読む。インポート時はセッション内の最終行を「セッション終了時の値」として扱う。
 
+Stop hook 入力には `duration` / `cost` フィールドが含まれないため、`transcript_path` で渡されるセッショントランスクリプトを jq で集計して取得する（`autolog_metrics_from_transcript`）。
+
 ```json
-{"ts":"...","type":"session_progress","session_id":"...","repo":"...","branch":"...","duration_ms":3899333,"cost_usd":1.234,"lines_added":120,"lines_removed":35}
+{"ts":"...","type":"session_progress","session_id":"...","repo":"...","branch":"...","duration_ms":22732315,"turn_count":390,"input_tokens":605,"output_tokens":482252,"cache_read_input_tokens":62459268,"cache_creation_input_tokens":1690357}
 ```
 
 | 追加 field | 由来 | 備考 |
 |---|---|---|
-| `duration_ms` | `.cost.total_duration_ms`、無ければ `session_start.ts` との差分で算出 | 累積 |
-| `cost_usd` | `.cost.total_cost_usd` | 累積。取れない環境では省略 |
-| `lines_added` / `lines_removed` | `.cost.total_lines_*` | 累積。取れない環境では省略 |
+| `duration_ms` | transcript の最初〜最後のタイムスタンプ差分。なければ `session_start.ts` との差分にフォールバック | 累積 |
+| `turn_count` | transcript 内の `type:"assistant"` 行数 | ≒ ターン数 |
+| `input_tokens` | `message.usage.input_tokens` 合算 | 累積（キャッシュ抜きの新規入力） |
+| `output_tokens` | `message.usage.output_tokens` 合算 | 累積 |
+| `cache_read_input_tokens` | 同 cache_read 合算 | 累積（安価なキャッシュヒット） |
+| `cache_creation_input_tokens` | 同 cache_creation 合算 | 累積 |
+
+### `session_end`
+
+`SessionEnd` フックでセッション終了時に一度だけ書かれる。終了理由 (`end_reason`) と最終累積値を持つ。フィールドは `session_progress` と同じに加えて：
+
+```json
+{"ts":"...","type":"session_end","session_id":"...","repo":"...","branch":"...","end_reason":"clear","duration_ms":...,"turn_count":...,...}
+```
+
+| 追加 field | 由来 | 備考 |
+|---|---|---|
+| `end_reason` | hook 入力 `.end_reason` | `clear` / `resume` / `logout` / `prompt_input_exit` 等 |
+
+`SessionEnd` は **発火が保証されない**（端末強制終了等で出ない場合がある）。そのため import 側は `session_progress` と `session_end` の両方を「セッション末値の候補」として扱い、各セッションの最新タイムスタンプ行を採用する。
 
 ### `git_commit`
 
@@ -117,6 +137,9 @@ push 完了は「完了候補」シグナルとして使う。実際の commit �
     ],
     "Stop": [
       { "hooks": [{ "type": "command", "command": "bash .claude/hooks/autolog-stop.sh" }] }
+    ],
+    "SessionEnd": [
+      { "hooks": [{ "type": "command", "command": "bash .claude/hooks/autolog-session-end.sh" }] }
     ],
     "PostToolUse": [
       { "matcher": "Bash", "hooks": [{ "type": "command", "command": "bash .claude/hooks/autolog-posttool.sh" }] }
@@ -175,13 +198,13 @@ tail -n 20 $EVENTS | jq -c '{ts, type, repo, branch}'
 # あるセッションの全イベント
 jq -c 'select(.session_id == "<id>")' $EVENTS
 
-# repo ごとの累計コスト（最終 session_progress を採用）
+# repo ごとの累計トークン（最終 progress/end を採用）
 jq -s '
-  map(select(.type=="session_progress"))
+  map(select(.type=="session_progress" or .type=="session_end"))
   | group_by(.session_id)
-  | map({repo: (.[0].repo // ""), cost: (last.cost_usd // 0)})
+  | map({repo: (.[0].repo // ""), out: (last.output_tokens // 0), dur: (last.duration_ms // 0)})
   | group_by(.repo)
-  | map({repo: .[0].repo, total: (map(.cost) | add)})
+  | map({repo: .[0].repo, total_output_tokens: (map(.out) | add), total_duration_ms: (map(.dur) | add)})
 ' $EVENTS
 
 # 今日触ったブランチ一覧（repo × branch）

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,48 +1,66 @@
 # Claude Code Auto-Log Hooks
 
-Claude Code の hooks を「タイムカード」として使い、作業イベントを `.claude/tmp/autolog/events.jsonl` に追記するスクリプト群。後段で InsightLog のタスクログにインポートする想定。
+Claude Code の hooks を「タイムカード」として使い、作業イベントを **追記専用 JSONL** に積むスクリプト群。**1日1回まとめて InsightLog にインポートする運用** を前提に設計している。リポジトリ横断のタスク（複数 repo を行き来する開発）にも対応する。
 
 ## 設計方針
 
-- **`.claude/tmp/` 配下にだけ書き出す**（gitignore 済み）。リポジトリは汚さない。
+- **既定の出力先はユーザーホーム配下**：`$HOME/.claude/tmp/autolog/events.jsonl`。複数リポジトリの作業を1箇所に集約する。
 - **追記専用 JSONL**。並行追記に強く、壊れにくい。
 - **失敗してもツール実行をブロックしない**。フックスクリプトは常に `exit 0`。
 - **プロジェクト内 `.claude/settings.json` で配線**。ユーザー設定 (`~/.claude/settings.json`) は触らない。
+- **イベントには必ず `repo`（git toplevel）と `repo_remote`（origin URL）を載せる**。横断集計の主キー。
+
+## 出力先の解決順
+
+1. `INSIGHTLOG_AUTOLOG_DIR` 環境変数があればそれを使う（テスト・個別運用向け）
+2. なければ `$HOME/.claude/tmp/autolog/`（既定。リポジトリ横断）
+3. `$HOME` も無い場合は `$CLAUDE_PROJECT_DIR/.claude/tmp/autolog` または `$PWD/.claude/tmp/autolog`
+
+リポ内 `.claude/tmp/` は `.gitignore` 済みなので、override してもコミット汚染しない。
 
 ## ファイル配置
 
 ```
-.claude/
-  hooks/
-    autolog-common.sh         # 共通: JSONL 追記関数・パス決定
-    autolog-session-start.sh  # SessionStart 用
-    autolog-stop.sh           # Stop 用
-    autolog-posttool.sh       # PostToolUse(Bash) 用、git 系コマンドを検出
-    README.md                 # 本ファイル
-  tmp/                        # gitignored
-    autolog/
-      events.jsonl            # メインのイベントログ（追記専用）
-      sessions/
-        <session_id>.start    # 開始 ts 保存。Stop hook で duration 計算に使う
+.claude/hooks/
+  autolog-common.sh         # 共通: 出力先解決・タイムスタンプ・JSONL 追記・git 情報取得
+  autolog-session-start.sh  # SessionStart 用
+  autolog-stop.sh           # Stop 用（毎ターン累積メトリクス）
+  autolog-posttool.sh       # PostToolUse(Bash) 用、git 系コマンドを検出
+  autolog-daily-report.sh   # 日次サマリーを Markdown で標準出力
+  README.md                 # 本ファイル
+
+$HOME/.claude/tmp/autolog/      # 既定の出力先（または INSIGHTLOG_AUTOLOG_DIR）
+  events.jsonl                  # メインのイベントログ（全リポ集約・追記専用）
+  sessions/
+    <session_id>.start          # 開始 ts 保存。Stop hook の duration fallback に使う
 ```
 
 ## イベントスキーマ
 
-各行は 1 JSON。`ts` は ISO 8601 UTC、`session_id` は Claude Code が提供する値。
+各行は 1 JSON。`ts` は ISO 8601 UTC ミリ秒精度。`session_id` は Claude Code が hook 入力で供給する値。
+
+### 共通フィールド（多くのイベントに付く）
+
+| field | 由来 | 備考 |
+|---|---|---|
+| `ts` | スクリプト実行時刻 | UTC ISO 8601 |
+| `session_id` | hook 入力 `.session_id` | Claude Code 採番 |
+| `cwd` | hook 入力 `.cwd` | Claude Code の作業ディレクトリ。hook 内で `cd` して以下の git 情報を取る |
+| `repo` | `git rev-parse --show-toplevel` | リポジトリのトップレベル絶対パス |
+| `repo_remote` | `git remote get-url origin`（不在時は最初の remote） | 横断集計の主キー候補 |
+| `branch` | `git symbolic-ref --short HEAD` | detached HEAD では省略 |
+
+git リポでないディレクトリで実行された場合は `repo` / `branch` / `repo_remote` は省略される。
 
 ### `session_start`
 
 ```json
-{"ts":"2026-05-18T10:00:01.234Z","type":"session_start","session_id":"abc123","cwd":"/workspaces/InsightLog","branch":"feat/x","head_sha":"a1b2c3d","source":"startup"}
+{"ts":"...","type":"session_start","session_id":"...","cwd":"...","repo":"...","repo_remote":"...","branch":"feat/x","head_sha":"a1b2c3d","source":"startup"}
 ```
 
-| field | 由来 | 備考 |
+| 追加 field | 由来 | 備考 |
 |---|---|---|
-| `ts` | 実行時刻 | UTC ISO 8601 |
-| `session_id` | hook 入力 `.session_id` | Claude Code 採番 |
-| `cwd` | hook 入力 `.cwd` | 実行ディレクトリ |
-| `branch` | `git symbolic-ref` | git リポでない場合は省略 |
-| `head_sha` | `git rev-parse HEAD` | short SHA |
+| `head_sha` | `git rev-parse --short HEAD` | セッション開始時点の HEAD |
 | `source` | hook 入力 `.source` | `startup` / `resume` / `clear` / `compact` |
 
 ### `session_progress`
@@ -50,46 +68,46 @@ Claude Code の hooks を「タイムカード」として使い、作業イベ�
 Claude Code の `Stop` フックは **毎ターン終了時に発火する**（セッション終了時だけではない）。なので各行は「そのターン終了時点の累積値スナップショット」として読む。インポート時はセッション内の最終行を「セッション終了時の値」として扱う。
 
 ```json
-{"ts":"2026-05-18T11:05:00.567Z","type":"session_progress","session_id":"abc123","duration_ms":3899333,"cost_usd":1.234,"lines_added":120,"lines_removed":35}
+{"ts":"...","type":"session_progress","session_id":"...","repo":"...","branch":"...","duration_ms":3899333,"cost_usd":1.234,"lines_added":120,"lines_removed":35}
 ```
 
-| field | 由来 | 備考 |
+| 追加 field | 由来 | 備考 |
 |---|---|---|
-| `duration_ms` | Stop hook 入力 `.cost.total_duration_ms`、なければ `session_start.ts` との差分から計算 | 累積 |
-| `cost_usd` | Stop hook 入力 `.cost.total_cost_usd` | 累積。取れない環境では省略 |
-| `lines_added` / `lines_removed` | Stop hook 入力 `.cost.total_lines_*` | 累積。取れない環境では省略 |
+| `duration_ms` | `.cost.total_duration_ms`、無ければ `session_start.ts` との差分で算出 | 累積 |
+| `cost_usd` | `.cost.total_cost_usd` | 累積。取れない環境では省略 |
+| `lines_added` / `lines_removed` | `.cost.total_lines_*` | 累積。取れない環境では省略 |
 
 ### `git_commit`
 
 ```json
-{"ts":"...","type":"git_commit","session_id":"...","branch":"feat/x","commit":"a1b2c3","subject":"feat: add hooks","files":12,"cwd":"..."}
+{"ts":"...","type":"git_commit","session_id":"...","cwd":"...","repo":"...","repo_remote":"...","branch":"feat/x","commit":"a1b2c3","subject":"feat: ...","files":12}
 ```
 
-| field | 由来 | 備考 |
+| 追加 field | 由来 | 備考 |
 |---|---|---|
 | `commit` | `git rev-parse --short HEAD` | post-commit 時点の HEAD |
-| `subject` | `git log -1 --pretty=%s` | 1行目のみ |
-| `files` | `git show --stat HEAD` から件数抽出 | 変更ファイル数 |
+| `subject` | `git log -1 --pretty=%s` | コミットメッセージ1行目 |
+| `files` | `git diff-tree --no-commit-id --name-only -r HEAD \| wc -l` | 変更ファイル数 |
 
 ### `git_push`
 
 ```json
-{"ts":"...","type":"git_push","session_id":"...","branch":"feat/x","command":"git push origin feat/x","cwd":"..."}
+{"ts":"...","type":"git_push","session_id":"...","cwd":"...","repo":"...","branch":"feat/x","command":"git push origin feat/x"}
 ```
 
-push 完了は「完了候補」シグナルとして使う。実際の commit 範囲は別途 InsightLog 側でブランチ × 時間窓から決定する。
+push 完了は「完了候補」シグナルとして使う。実際の commit 範囲は別途 InsightLog 側で `repo × branch × 時間窓` から決定する。
 
 ### `git_checkout`
 
 ```json
-{"ts":"...","type":"git_checkout","session_id":"...","to_branch":"feat/y","from_branch":"feat/x","command":"git switch feat/y","cwd":"..."}
+{"ts":"...","type":"git_checkout","session_id":"...","cwd":"...","repo":"...","branch":"feat/y","to_branch":"feat/y","from_branch":"feat/x","command":"git switch feat/y"}
 ```
 
-`from_branch` は `git reflog -1 HEAD@{1}` から抽出（取れない場合は省略）。
+`from_branch` は `git reflog -1 HEAD@{0}` の `gs` フォーマットから抽出（`checkout: moving from X to Y` 形式）。取れない場合は省略。
 
 ## hooks 配線
 
-`.claude/settings.json` の `hooks` に以下を登録：
+`.claude/settings.json` の `hooks` に登録（このリポでは設定済み）：
 
 ```jsonc
 {
@@ -107,21 +125,73 @@ push 完了は「完了候補」シグナルとして使う。実際の commit �
 }
 ```
 
-## 確認方法
+別リポでも同じ運用にしたい場合は、各リポの `.claude/settings.json` に同じ配線を書く。出力先は既定で `$HOME/.claude/tmp/autolog/` に集約されるので、ログは一箇所に貯まる。
+
+## 日次レポート
+
+1日の終わりに `autolog-daily-report.sh` を実行すると、その日のセッションとコミットを repo × branch でグルーピングした Markdown が出る。これを InsightLog の手動入力時のリファレンスに使う。
 
 ```bash
-# 直近のイベントを見る
-tail -n 20 .claude/tmp/autolog/events.jsonl | jq -c '{ts, type, branch, session_id}'
+# 今日（UTC）
+.claude/hooks/autolog-daily-report.sh
+
+# 指定日
+.claude/hooks/autolog-daily-report.sh 2026-05-18
+
+# 範囲
+.claude/hooks/autolog-daily-report.sh --since 2026-05-15 --until 2026-05-18
+```
+
+出力例：
+
+```markdown
+# InsightLog autolog 日次レポート
+
+- 期間: 2026-05-18 〜 2026-05-18 (UTC)
+- イベント総数: 42 / セッション開始: 3 / コミット: 8 / プッシュ: 2 / ブランチ切替: 5
+
+## セッション集計
+
+| session_id | repo | branch | duration | cost(USD) | +行/-行 |
+|---|---|---|---:|---:|---:|
+| abc12345 | InsightLog | feat/x | 1h20m | $1.23 | +120/-35 |
+| def67890 | other-repo | feat/y | 45m | $0.67 | +40/-10 |
+
+## リポジトリ × ブランチ別コミット
+
+### InsightLog / feat/x (3 commits)
+- `a1b2c3d` feat: 〜〜 — 2026-05-18T10:32:14Z
+...
+```
+
+## アドホックなクエリ
+
+```bash
+EVENTS=$HOME/.claude/tmp/autolog/events.jsonl
+
+# 直近のイベント
+tail -n 20 $EVENTS | jq -c '{ts, type, repo, branch}'
 
 # あるセッションの全イベント
-jq -c 'select(.session_id == "<id>")' .claude/tmp/autolog/events.jsonl
+jq -c 'select(.session_id == "<id>")' $EVENTS
 
-# 累計コスト
-jq -s 'map(select(.type=="session_stop") | .cost_usd) | add' .claude/tmp/autolog/events.jsonl
+# repo ごとの累計コスト（最終 session_progress を採用）
+jq -s '
+  map(select(.type=="session_progress"))
+  | group_by(.session_id)
+  | map({repo: (.[0].repo // ""), cost: (last.cost_usd // 0)})
+  | group_by(.repo)
+  | map({repo: .[0].repo, total: (map(.cost) | add)})
+' $EVENTS
+
+# 今日触ったブランチ一覧（repo × branch）
+TODAY=$(date -u +%Y-%m-%d)
+jq -r --arg d $TODAY 'select(.ts | startswith($d)) | "\(.repo // "?") / \(.branch // "?")"' $EVENTS | sort -u
 ```
 
 ## 既知の制約
 
-1. **Claude Code 起動中の作業しか測れない**。手動の作業時間は別途記録が要る。
-2. **複数 Claude Code 並行起動**は session_id で識別できるが、人間が「同じタスクをやっていた」ことを判別するのは後段の InsightLog 側ロジック。
-3. **`git push` 後の HEAD 範囲は post-hook では取れない**。push 直前にローカル `@{u}..HEAD` を残す PreToolUse を後で追加する余地あり。
+1. **Claude Code 起動中の作業しか測れない**。エディタだけ開いて作業した時間は別途記録が要る。
+2. **複数 Claude Code 並行起動** は session_id で識別できるが、人間が「同じタスクをやっていた」ことを後段で紐付ける必要がある（commit メッセージや branch 名で判別）。
+3. **`cd /other && git ...` で別 repo を触った時**、hook は入力 `.cwd` をベースに git 情報を読むので大半は正しく検出するが、`.cwd` 更新が反映されていないタイミングでは元 repo として記録される可能性がある。確実に切り替えたい時は `cd` を独立した Bash 呼び出しにする。
+4. **`git push` 後の HEAD 範囲** は post-hook では取れない。必要になったら push 直前に `@{u}..HEAD` を残す PreToolUse を追加する。

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -150,6 +150,41 @@ push 完了は「完了候補」シグナルとして使う。実際の commit �
 
 別リポでも同じ運用にしたい場合は、各リポの `.claude/settings.json` に同じ配線を書く。出力先は既定で `$HOME/.claude/tmp/autolog/` に集約されるので、ログは一箇所に貯まる。
 
+## events.jsonl の削減
+
+events.jsonl は追記専用で、放置すると単調に増え続ける。削減方法は 2 つあり、用途で使い分ける。
+
+### 1. ブラウザ取り込み時の物理削除（自動・推奨）
+
+ImportModal で下書きを確定（タスクとして保存）した瞬間に、events.jsonl から該当イベントが物理削除される。
+
+- File System Access API が必要（Chromium 系のみ）
+- 初回のファイル選択時に「書込権限」のダイアログが出る。許可すれば以降の取り込みでは自動削除される
+- 並行書込 race の対策として「書き戻し直前に再読込して新規追記分を保全」する実装
+- 権限が拒否されている / 非対応ブラウザでは IndexedDB の「取り込み済み」フラグだけで重複防止する（events.jsonl は変わらない）
+
+実装は `src/lib/autologMaintenance.ts` の `purgeImportedFromJsonl`。
+
+### 2. `autolog-compact.sh` — session_progress の集約圧縮
+
+同一 `session_id` の `session_progress` は累積値なので、最新 1 件だけ残せば情報損失なし。`session_start` / `session_end` / `git_*` は全部維持する。
+
+```bash
+# デフォルト出力先を圧縮
+.claude/hooks/autolog-compact.sh
+
+# 任意のファイルを圧縮
+.claude/hooks/autolog-compact.sh /path/to/events.jsonl
+
+# dry-run（行数の試算だけ）
+INSIGHTLOG_COMPACT_DRY_RUN=1 .claude/hooks/autolog-compact.sh
+```
+
+- 並行追記対策: 圧縮中の追記分は `tail -c` で末尾だけ取り出して連結
+- 50 ターン/セッションのファイルなら 50→1 で約 98% 削減
+
+長期運用の目安: 月初に手動実行 or cron。自動化したくなったら `autolog-stop.sh` から行数閾値超過で呼ぶ追加可能（今は手動）。
+
 ## 日次レポート
 
 1日の終わりに `autolog-daily-report.sh` を実行すると、その日のセッションとコミットを repo × branch でグルーピングした Markdown が出る。これを InsightLog の手動入力時のリファレンスに使う。
@@ -218,3 +253,4 @@ jq -r --arg d $TODAY 'select(.ts | startswith($d)) | "\(.repo // "?") / \(.branc
 2. **複数 Claude Code 並行起動** は session_id で識別できるが、人間が「同じタスクをやっていた」ことを後段で紐付ける必要がある（commit メッセージや branch 名で判別）。
 3. **`cd /other && git ...` で別 repo を触った時**、hook は入力 `.cwd` をベースに git 情報を読むので大半は正しく検出するが、`.cwd` 更新が反映されていないタイミングでは元 repo として記録される可能性がある。確実に切り替えたい時は `cd` を独立した Bash 呼び出しにする。
 4. **`git push` 後の HEAD 範囲** は post-hook では取れない。必要になったら push 直前に `@{u}..HEAD` を残す PreToolUse を追加する。
+5. **ブラウザ取り込み時の物理削除と autolog-compact.sh の race**: ほぼ無視できる時間窓だが、両者を全く同時に実行すると新規追記分のロストが理論上ありうる。手動 compact は Claude Code 非稼働時に実行が安全。

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,127 @@
+# Claude Code Auto-Log Hooks
+
+Claude Code の hooks を「タイムカード」として使い、作業イベントを `.claude/tmp/autolog/events.jsonl` に追記するスクリプト群。後段で InsightLog のタスクログにインポートする想定。
+
+## 設計方針
+
+- **`.claude/tmp/` 配下にだけ書き出す**（gitignore 済み）。リポジトリは汚さない。
+- **追記専用 JSONL**。並行追記に強く、壊れにくい。
+- **失敗してもツール実行をブロックしない**。フックスクリプトは常に `exit 0`。
+- **プロジェクト内 `.claude/settings.json` で配線**。ユーザー設定 (`~/.claude/settings.json`) は触らない。
+
+## ファイル配置
+
+```
+.claude/
+  hooks/
+    autolog-common.sh         # 共通: JSONL 追記関数・パス決定
+    autolog-session-start.sh  # SessionStart 用
+    autolog-stop.sh           # Stop 用
+    autolog-posttool.sh       # PostToolUse(Bash) 用、git 系コマンドを検出
+    README.md                 # 本ファイル
+  tmp/                        # gitignored
+    autolog/
+      events.jsonl            # メインのイベントログ（追記専用）
+      sessions/
+        <session_id>.start    # 開始 ts 保存。Stop hook で duration 計算に使う
+```
+
+## イベントスキーマ
+
+各行は 1 JSON。`ts` は ISO 8601 UTC、`session_id` は Claude Code が提供する値。
+
+### `session_start`
+
+```json
+{"ts":"2026-05-18T10:00:01.234Z","type":"session_start","session_id":"abc123","cwd":"/workspaces/InsightLog","branch":"feat/x","head_sha":"a1b2c3d","source":"startup"}
+```
+
+| field | 由来 | 備考 |
+|---|---|---|
+| `ts` | 実行時刻 | UTC ISO 8601 |
+| `session_id` | hook 入力 `.session_id` | Claude Code 採番 |
+| `cwd` | hook 入力 `.cwd` | 実行ディレクトリ |
+| `branch` | `git symbolic-ref` | git リポでない場合は省略 |
+| `head_sha` | `git rev-parse HEAD` | short SHA |
+| `source` | hook 入力 `.source` | `startup` / `resume` / `clear` / `compact` |
+
+### `session_progress`
+
+Claude Code の `Stop` フックは **毎ターン終了時に発火する**（セッション終了時だけではない）。なので各行は「そのターン終了時点の累積値スナップショット」として読む。インポート時はセッション内の最終行を「セッション終了時の値」として扱う。
+
+```json
+{"ts":"2026-05-18T11:05:00.567Z","type":"session_progress","session_id":"abc123","duration_ms":3899333,"cost_usd":1.234,"lines_added":120,"lines_removed":35}
+```
+
+| field | 由来 | 備考 |
+|---|---|---|
+| `duration_ms` | Stop hook 入力 `.cost.total_duration_ms`、なければ `session_start.ts` との差分から計算 | 累積 |
+| `cost_usd` | Stop hook 入力 `.cost.total_cost_usd` | 累積。取れない環境では省略 |
+| `lines_added` / `lines_removed` | Stop hook 入力 `.cost.total_lines_*` | 累積。取れない環境では省略 |
+
+### `git_commit`
+
+```json
+{"ts":"...","type":"git_commit","session_id":"...","branch":"feat/x","commit":"a1b2c3","subject":"feat: add hooks","files":12,"cwd":"..."}
+```
+
+| field | 由来 | 備考 |
+|---|---|---|
+| `commit` | `git rev-parse --short HEAD` | post-commit 時点の HEAD |
+| `subject` | `git log -1 --pretty=%s` | 1行目のみ |
+| `files` | `git show --stat HEAD` から件数抽出 | 変更ファイル数 |
+
+### `git_push`
+
+```json
+{"ts":"...","type":"git_push","session_id":"...","branch":"feat/x","command":"git push origin feat/x","cwd":"..."}
+```
+
+push 完了は「完了候補」シグナルとして使う。実際の commit 範囲は別途 InsightLog 側でブランチ × 時間窓から決定する。
+
+### `git_checkout`
+
+```json
+{"ts":"...","type":"git_checkout","session_id":"...","to_branch":"feat/y","from_branch":"feat/x","command":"git switch feat/y","cwd":"..."}
+```
+
+`from_branch` は `git reflog -1 HEAD@{1}` から抽出（取れない場合は省略）。
+
+## hooks 配線
+
+`.claude/settings.json` の `hooks` に以下を登録：
+
+```jsonc
+{
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [{ "type": "command", "command": "bash .claude/hooks/autolog-session-start.sh" }] }
+    ],
+    "Stop": [
+      { "hooks": [{ "type": "command", "command": "bash .claude/hooks/autolog-stop.sh" }] }
+    ],
+    "PostToolUse": [
+      { "matcher": "Bash", "hooks": [{ "type": "command", "command": "bash .claude/hooks/autolog-posttool.sh" }] }
+    ]
+  }
+}
+```
+
+## 確認方法
+
+```bash
+# 直近のイベントを見る
+tail -n 20 .claude/tmp/autolog/events.jsonl | jq -c '{ts, type, branch, session_id}'
+
+# あるセッションの全イベント
+jq -c 'select(.session_id == "<id>")' .claude/tmp/autolog/events.jsonl
+
+# 累計コスト
+jq -s 'map(select(.type=="session_stop") | .cost_usd) | add' .claude/tmp/autolog/events.jsonl
+```
+
+## 既知の制約
+
+1. **Claude Code 起動中の作業しか測れない**。手動の作業時間は別途記録が要る。
+2. **複数 Claude Code 並行起動**は session_id で識別できるが、人間が「同じタスクをやっていた」ことを判別するのは後段の InsightLog 側ロジック。
+3. **`git push` 後の HEAD 範囲は post-hook では取れない**。push 直前にローカル `@{u}..HEAD` を残す PreToolUse を後で追加する余地あり。

--- a/.claude/hooks/autolog-common.sh
+++ b/.claude/hooks/autolog-common.sh
@@ -2,8 +2,20 @@
 # autolog-common.sh — InsightLog autolog hook の共通関数
 # 直接実行せず、各 hook スクリプトから `.` (source) して使う。
 
-# 出力先ディレクトリ。CLAUDE_PROJECT_DIR があればそれを優先。
+# 出力先ディレクトリ。
+# 解決順:
+#   1) $INSIGHTLOG_AUTOLOG_DIR（明示指定、テストや個別運用向け）
+#   2) $HOME/.claude/tmp/autolog（既定。リポジトリ横断で1箇所に集約する）
+#   3) $CLAUDE_PROJECT_DIR/.claude/tmp/autolog または $PWD/.claude/tmp/autolog（HOME 不在時のフォールバック）
 autolog_dir() {
+  if [ -n "${INSIGHTLOG_AUTOLOG_DIR:-}" ]; then
+    echo "$INSIGHTLOG_AUTOLOG_DIR"
+    return
+  fi
+  if [ -n "${HOME:-}" ]; then
+    echo "$HOME/.claude/tmp/autolog"
+    return
+  fi
   local base="${CLAUDE_PROJECT_DIR:-$PWD}"
   echo "$base/.claude/tmp/autolog"
 }
@@ -34,6 +46,20 @@ autolog_head_sha() {
   git --no-optional-locks rev-parse --short HEAD 2>/dev/null || true
 }
 
+# Git リポジトリのトップレベル絶対パス（リポでなければ空）
+autolog_repo_root() {
+  git --no-optional-locks rev-parse --show-toplevel 2>/dev/null || true
+}
+
+# origin の URL。無ければ最初に見つかった remote の URL。
+autolog_repo_remote() {
+  git --no-optional-locks remote get-url origin 2>/dev/null && return
+  local first_remote
+  first_remote=$(git --no-optional-locks remote 2>/dev/null | head -1)
+  [ -n "$first_remote" ] || return 0
+  git --no-optional-locks remote get-url "$first_remote" 2>/dev/null || true
+}
+
 # epoch ミリ秒（GNU date 想定。失敗時は空）
 autolog_epoch_ms() {
   date -u +%s%3N 2>/dev/null || true
@@ -44,4 +70,12 @@ autolog_iso_to_epoch_ms() {
   local iso="$1"
   [ -z "$iso" ] && return 0
   date -u -d "$iso" +%s%3N 2>/dev/null || true
+}
+
+# 指定ディレクトリにいる体で git 情報を読みたいとき、安全に cd する
+# $1: 候補ディレクトリ。存在しなければ無視（cd しない）。
+autolog_enter_cwd() {
+  local target="$1"
+  [ -n "$target" ] && [ -d "$target" ] && cd "$target" 2>/dev/null
+  return 0
 }

--- a/.claude/hooks/autolog-common.sh
+++ b/.claude/hooks/autolog-common.sh
@@ -20,9 +20,17 @@ autolog_dir() {
   echo "$base/.claude/tmp/autolog"
 }
 
-# ISO 8601 UTC、ミリ秒精度（取れなければ秒精度）
+# ISO 8601 UTC、ミリ秒精度。
+# 注意: GNU date の `%3N` は macOS の BSD date で literal `%3N` になってしまうため、
+# プラットフォーム非依存のために jq で生成する。
 autolog_ts() {
-  date -u +"%Y-%m-%dT%H:%M:%S.%3NZ" 2>/dev/null || date -u +"%Y-%m-%dT%H:%M:%SZ"
+  jq -nr '
+    now as $t |
+    ($t | floor) as $sec |
+    (($t - $sec) * 1000 | floor) as $ms |
+    ($sec | gmtime | strftime("%Y-%m-%dT%H:%M:%S")) as $base |
+    $base + (if $ms < 10 then ".00\($ms)" elif $ms < 100 then ".0\($ms)" else ".\($ms)" end) + "Z"
+  '
 }
 
 # 必要ディレクトリを作る
@@ -85,16 +93,26 @@ autolog_repo_remote() {
   git --no-optional-locks remote get-url "$first_remote" 2>/dev/null || true
 }
 
-# epoch ミリ秒（GNU date 想定。失敗時は空）
+# 現在時刻 → epoch ms。jq の now を使うのでプラットフォーム非依存。
 autolog_epoch_ms() {
-  date -u +%s%3N 2>/dev/null || true
+  jq -nr 'now * 1000 | floor' 2>/dev/null || true
 }
 
-# ISO 8601 文字列 → epoch ms（GNU date のみ）
+# ISO 8601 文字列 → epoch ms。
+# jq の fromdateiso8601 は秒精度のみ対応のため、小数秒を別途取り出して加算する。
 autolog_iso_to_epoch_ms() {
   local iso="$1"
   [ -z "$iso" ] && return 0
-  date -u -d "$iso" +%s%3N 2>/dev/null || true
+  jq -nr --arg ts "$iso" '
+    # 小数秒（.123Z 等）を捕捉
+    ($ts | capture("\\.(?<f>[0-9]+)Z$") // {f: "0"}) as $frac |
+    # 小数秒を取り除いた整数秒部
+    ($ts | sub("\\.[0-9]+Z$"; "Z")) as $clean |
+    ($clean | fromdateiso8601 * 1000) as $base |
+    # frac を 3 桁に正規化 ("812" → 812ms, "5" → 500ms, "12" → 120ms, "1234" → 123ms)
+    (($frac.f + "000")[0:3] | tonumber) as $ms |
+    $base + $ms
+  ' 2>/dev/null || true
 }
 
 # 指定ディレクトリにいる体で git 情報を読みたいとき、安全に cd する

--- a/.claude/hooks/autolog-common.sh
+++ b/.claude/hooks/autolog-common.sh
@@ -46,6 +46,31 @@ autolog_head_sha() {
   git --no-optional-locks rev-parse --short HEAD 2>/dev/null || true
 }
 
+# transcript ファイルからセッション累計メトリクスを JSON 1 行で出力。
+# 引数: $1 transcript_path
+# 出力フィールド: duration_ms / turn_count / input_tokens / output_tokens / cache_read_input_tokens / cache_creation_input_tokens
+# 取れないフィールドは省略。transcript 不在なら空文字を返す。
+autolog_metrics_from_transcript() {
+  local path="$1"
+  [ -n "$path" ] && [ -f "$path" ] || return 0
+
+  # 累計 usage と最初/最後のタイムスタンプを 1 パスで集計
+  jq -s '
+    def usages: [.[] | select(.message.usage != null) | .message.usage];
+    def tsmin: [.[].timestamp | select(. != null)] | sort | first // empty;
+    def tsmax: [.[].timestamp | select(. != null)] | sort | last // empty;
+    {
+      _first: tsmin,
+      _last: tsmax,
+      turn_count: ([.[] | select(.type == "assistant")] | length),
+      input_tokens: (usages | map(.input_tokens // 0) | add // 0),
+      output_tokens: (usages | map(.output_tokens // 0) | add // 0),
+      cache_read_input_tokens: (usages | map(.cache_read_input_tokens // 0) | add // 0),
+      cache_creation_input_tokens: (usages | map(.cache_creation_input_tokens // 0) | add // 0)
+    }
+  ' "$path" 2>/dev/null || true
+}
+
 # Git リポジトリのトップレベル絶対パス（リポでなければ空）
 autolog_repo_root() {
   git --no-optional-locks rev-parse --show-toplevel 2>/dev/null || true

--- a/.claude/hooks/autolog-common.sh
+++ b/.claude/hooks/autolog-common.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# autolog-common.sh — InsightLog autolog hook の共通関数
+# 直接実行せず、各 hook スクリプトから `.` (source) して使う。
+
+# 出力先ディレクトリ。CLAUDE_PROJECT_DIR があればそれを優先。
+autolog_dir() {
+  local base="${CLAUDE_PROJECT_DIR:-$PWD}"
+  echo "$base/.claude/tmp/autolog"
+}
+
+# ISO 8601 UTC、ミリ秒精度（取れなければ秒精度）
+autolog_ts() {
+  date -u +"%Y-%m-%dT%H:%M:%S.%3NZ" 2>/dev/null || date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+# 必要ディレクトリを作る
+autolog_init() {
+  mkdir -p "$(autolog_dir)/sessions"
+}
+
+# JSON 1 行を events.jsonl に追記
+# $1: 完成済み JSON 文字列（改行なし）
+autolog_append() {
+  autolog_init
+  printf '%s\n' "$1" >> "$(autolog_dir)/events.jsonl"
+}
+
+# 現在の git ブランチ（rev-parse 単独だと detached HEAD で短 SHA を返してしまうため二段構え）
+autolog_branch() {
+  git --no-optional-locks symbolic-ref --short HEAD 2>/dev/null || true
+}
+
+autolog_head_sha() {
+  git --no-optional-locks rev-parse --short HEAD 2>/dev/null || true
+}
+
+# epoch ミリ秒（GNU date 想定。失敗時は空）
+autolog_epoch_ms() {
+  date -u +%s%3N 2>/dev/null || true
+}
+
+# ISO 8601 文字列 → epoch ms（GNU date のみ）
+autolog_iso_to_epoch_ms() {
+  local iso="$1"
+  [ -z "$iso" ] && return 0
+  date -u -d "$iso" +%s%3N 2>/dev/null || true
+}

--- a/.claude/hooks/autolog-compact.sh
+++ b/.claude/hooks/autolog-compact.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# autolog-compact.sh — events.jsonl を圧縮する
+#
+# 同一 session_id の session_progress は累積値なので、最新の1行だけ残せば
+# 情報損失なく大幅に減らせる。session_start / session_end / git_* は全部残す。
+#
+# 使い方:
+#   .claude/hooks/autolog-compact.sh            # デフォルト出力先を対象
+#   .claude/hooks/autolog-compact.sh /path/to/events.jsonl
+#   INSIGHTLOG_AUTOLOG_DIR=... .claude/hooks/autolog-compact.sh
+#
+# 動作:
+#   1. 入力ファイルを別パスにコピー（snapshot）
+#   2. snapshot を jq で圧縮、tmp に書き出し
+#   3. tmp を入力ファイル位置に rename（原子的）
+#   4. snapshot 以降に追記された分があれば失わないよう、書き戻し直前に再読込して追加
+#
+# 注意:
+#   - 並行する hooks 追記との race window はゼロではない（書込開始〜rename 間）が、
+#     実用上は無視できる小さなウィンドウ。
+#   - dry-run したい場合は INSIGHTLOG_COMPACT_DRY_RUN=1 を指定。
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/autolog-common.sh"
+
+INPUT_FILE="${1:-$(autolog_dir)/events.jsonl}"
+DRY_RUN="${INSIGHTLOG_COMPACT_DRY_RUN:-0}"
+
+if [ ! -f "$INPUT_FILE" ]; then
+  echo "events.jsonl が見つかりません: $INPUT_FILE" >&2
+  exit 1
+fi
+
+BEFORE_LINES=$(wc -l < "$INPUT_FILE")
+BEFORE_BYTES=$(wc -c < "$INPUT_FILE")
+
+# Step 1: snapshot
+SNAPSHOT=$(mktemp)
+cp "$INPUT_FILE" "$SNAPSHOT"
+
+# Step 2: 圧縮
+# 全イベントを読み、session_progress については session_id ごとに最新だけ残す
+TMP_OUT=$(mktemp)
+jq -sc '
+  # session_progress を session_id ごとに集めて max_by(.ts) で 1 つだけ残す
+  (map(select(.type == "session_progress")) | group_by(.session_id) | map(max_by(.ts))) as $progress_kept
+  | (map(select(.type != "session_progress"))) as $others
+  | ($progress_kept + $others)
+  | sort_by(.ts)
+  | .[]
+' "$SNAPSHOT" > "$TMP_OUT"
+
+AFTER_LINES=$(wc -l < "$TMP_OUT")
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo "=== dry-run ==="
+  echo "  input:     $INPUT_FILE"
+  echo "  before:    $BEFORE_LINES lines / $BEFORE_BYTES bytes"
+  echo "  after:     $AFTER_LINES lines"
+  echo "  reduction: $((BEFORE_LINES - AFTER_LINES)) lines"
+  rm -f "$SNAPSHOT" "$TMP_OUT"
+  exit 0
+fi
+
+# Step 3: snapshot 以降の追記分を保全
+INPUT_NOW_BYTES=$(wc -c < "$INPUT_FILE")
+if [ "$INPUT_NOW_BYTES" -gt "$BEFORE_BYTES" ]; then
+  # snapshot 取得後に追記された行をそのまま付ける
+  tail -c "+$((BEFORE_BYTES + 1))" "$INPUT_FILE" >> "$TMP_OUT"
+fi
+
+# Step 4: 原子的に置換
+mv "$TMP_OUT" "$INPUT_FILE"
+rm -f "$SNAPSHOT"
+
+AFTER_BYTES=$(wc -c < "$INPUT_FILE")
+FINAL_LINES=$(wc -l < "$INPUT_FILE")
+
+echo "compacted: $INPUT_FILE"
+echo "  lines: $BEFORE_LINES → $FINAL_LINES ($((BEFORE_LINES - FINAL_LINES)) 行削減)"
+echo "  bytes: $BEFORE_BYTES → $AFTER_BYTES ($((BEFORE_BYTES - AFTER_BYTES)) バイト削減)"

--- a/.claude/hooks/autolog-daily-report.sh
+++ b/.claude/hooks/autolog-daily-report.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# autolog-daily-report.sh — events.jsonl から1日分のサマリーを Markdown で出す
+#
+# 使い方:
+#   .claude/hooks/autolog-daily-report.sh            # 今日（UTC）
+#   .claude/hooks/autolog-daily-report.sh 2026-05-18 # 指定日
+#   .claude/hooks/autolog-daily-report.sh --since 2026-05-15 --until 2026-05-18
+#
+# 出力先は標準出力。InsightLog 取り込み前の人間確認 / 日次まとめ用。
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/autolog-common.sh"
+
+EVENTS="$(autolog_dir)/events.jsonl"
+if [ ! -f "$EVENTS" ]; then
+  echo "events.jsonl not found at $EVENTS" >&2
+  exit 1
+fi
+
+# 引数解釈
+SINCE=""
+UNTIL=""
+if [ $# -eq 0 ]; then
+  SINCE="$(date -u +%Y-%m-%d)"
+  UNTIL="$SINCE"
+elif [ "$1" = "--since" ] || [ "$1" = "--until" ]; then
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --since) SINCE="$2"; shift 2 ;;
+      --until) UNTIL="$2"; shift 2 ;;
+      *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+  done
+  [ -n "$SINCE" ] || SINCE="1970-01-01"
+  [ -n "$UNTIL" ] || UNTIL="$(date -u +%Y-%m-%d)"
+else
+  SINCE="$1"
+  UNTIL="$1"
+fi
+
+# 範囲フィルタ → repo × branch ごとに集約
+jq -s --arg since "$SINCE" --arg until "$UNTIL" '
+  # 期間境界: [since 00:00:00Z, until+1day 00:00:00Z)
+  ($since + "T00:00:00.000Z") as $lo
+  | ($until + "T23:59:59.999Z") as $hi
+  | map(select(.ts >= $lo and .ts <= $hi))
+  | {
+      since: $since,
+      until: $until,
+      total_events: length,
+      sessions:    (map(select(.type == "session_start")) | length),
+      commits:     [.[] | select(.type == "git_commit")],
+      pushes:      [.[] | select(.type == "git_push")],
+      checkouts:   [.[] | select(.type == "git_checkout")],
+      progress:    [.[] | select(.type == "session_progress")],
+      # repo × branch ごとにコミット
+      by_repo_branch: (
+        [.[] | select(.type == "git_commit")]
+        | group_by([.repo, .branch])
+        | map({
+            repo:    (.[0].repo // "(unknown)"),
+            branch:  (.[0].branch // "(detached)"),
+            commits: map({ts, commit, subject, files}),
+            count:   length
+          })
+      ),
+      # セッション末の累積メトリクス（各 session_id の最後の session_progress）
+      session_totals: (
+        [.[] | select(.type == "session_progress")]
+        | group_by(.session_id)
+        | map({
+            session_id: .[0].session_id,
+            repo:       (.[0].repo // ""),
+            branch:     (.[0].branch // ""),
+            duration_ms:  (last.duration_ms  // 0),
+            cost_usd:     (last.cost_usd     // 0),
+            lines_added:  (last.lines_added  // 0),
+            lines_removed:(last.lines_removed// 0)
+          })
+      )
+    }
+' "$EVENTS" \
+| jq -r '
+  def fmt_dur(ms):
+    if ms == null or ms == 0 then "-"
+    else
+      (ms / 60000 | floor) as $m
+      | ($m / 60 | floor) as $h
+      | ($m % 60) as $mm
+      | if $h > 0 then "\($h)h\($mm)m" else "\($mm)m" end
+    end;
+  def short_repo(r): if r == null or r == "" then "(unknown)" else (r | split("/") | last) end;
+
+  "# InsightLog autolog 日次レポート",
+  "",
+  "- 期間: \(.since) 〜 \(.until) (UTC)",
+  "- イベント総数: \(.total_events) / セッション開始: \(.sessions) / コミット: \(.commits|length) / プッシュ: \(.pushes|length) / ブランチ切替: \(.checkouts|length)",
+  "",
+  "## セッション集計",
+  "",
+  if (.session_totals|length) == 0 then "(なし)"
+  else
+    "| session_id | repo | branch | duration | cost(USD) | +行/-行 |",
+    "|---|---|---|---:|---:|---:|",
+    (.session_totals[] | "| \(.session_id[0:8]) | \(short_repo(.repo)) | \(.branch) | \(fmt_dur(.duration_ms)) | $\(.cost_usd) | +\(.lines_added)/-\(.lines_removed) |")
+  end,
+  "",
+  "## リポジトリ × ブランチ別コミット",
+  "",
+  if (.by_repo_branch|length) == 0 then "(なし)"
+  else
+    (.by_repo_branch[] |
+      "### \(short_repo(.repo)) / \(.branch) (\(.count) commits)",
+      "",
+      (.commits[] | "- `\(.commit // "?")` \(.subject // "(no subject)") — \(.ts)"),
+      ""
+    )
+  end
+'

--- a/.claude/hooks/autolog-daily-report.sh
+++ b/.claude/hooks/autolog-daily-report.sh
@@ -54,7 +54,7 @@ jq -s --arg since "$SINCE" --arg until "$UNTIL" '
       commits:     [.[] | select(.type == "git_commit")],
       pushes:      [.[] | select(.type == "git_push")],
       checkouts:   [.[] | select(.type == "git_checkout")],
-      progress:    [.[] | select(.type == "session_progress")],
+      progress:    [.[] | select(.type == "session_progress" or .type == "session_end")],
       # repo × branch ごとにコミット
       by_repo_branch: (
         [.[] | select(.type == "git_commit")]
@@ -66,18 +66,18 @@ jq -s --arg since "$SINCE" --arg until "$UNTIL" '
             count:   length
           })
       ),
-      # セッション末の累積メトリクス（各 session_id の最後の session_progress）
+      # セッション末の累積メトリクス（各 session_id の最後の session_progress / session_end）
       session_totals: (
-        [.[] | select(.type == "session_progress")]
+        [.[] | select(.type == "session_progress" or .type == "session_end")]
         | group_by(.session_id)
         | map({
             session_id: .[0].session_id,
             repo:       (.[0].repo // ""),
             branch:     (.[0].branch // ""),
             duration_ms:  (last.duration_ms  // 0),
-            cost_usd:     (last.cost_usd     // 0),
-            lines_added:  (last.lines_added  // 0),
-            lines_removed:(last.lines_removed// 0)
+            turn_count:   (last.turn_count   // 0),
+            output_tokens:(last.output_tokens// 0),
+            cost_usd:     (last.cost_usd     // 0)
           })
       )
     }
@@ -102,9 +102,9 @@ jq -s --arg since "$SINCE" --arg until "$UNTIL" '
   "",
   if (.session_totals|length) == 0 then "(なし)"
   else
-    "| session_id | repo | branch | duration | cost(USD) | +行/-行 |",
+    "| session_id | repo | branch | duration | turns | output tok |",
     "|---|---|---|---:|---:|---:|",
-    (.session_totals[] | "| \(.session_id[0:8]) | \(short_repo(.repo)) | \(.branch) | \(fmt_dur(.duration_ms)) | $\(.cost_usd) | +\(.lines_added)/-\(.lines_removed) |")
+    (.session_totals[] | "| \(.session_id[0:8]) | \(short_repo(.repo)) | \(.branch) | \(fmt_dur(.duration_ms)) | \(.turn_count) | \(.output_tokens) |")
   end,
   "",
   "## リポジトリ × ブランチ別コミット",

--- a/.claude/hooks/autolog-posttool.sh
+++ b/.claude/hooks/autolog-posttool.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# PostToolUse(Bash) hook — Bash 実行コマンドから git イベントを検出して追記
+# 期待される hook 入力（抜粋）: { session_id, cwd, tool_name, tool_input: { command } }
+# 検出対象: git commit / push / checkout / switch
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/autolog-common.sh"
+
+INPUT=$(cat)
+
+tool_name=$(echo "$INPUT" | jq -r '.tool_name // ""')
+[ "$tool_name" = "Bash" ] || exit 0
+
+cmd=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+[ -n "$cmd" ] || exit 0
+
+# 最初に現れる git サブコマンドだけを拾う
+# 例: "git commit -m '...'", "cd /foo && git push origin main"
+subcmd=$(printf '%s' "$cmd" | grep -oE 'git +(commit|push|checkout|switch)\b' | head -1 | awk '{print $2}')
+[ -n "$subcmd" ] || exit 0
+
+session_id=$(echo "$INPUT" | jq -r '.session_id // ""')
+cwd=$(echo "$INPUT" | jq -r '.cwd // ""')
+ts=$(autolog_ts)
+branch=$(autolog_branch)
+
+case "$subcmd" in
+  commit)
+    commit_sha=$(autolog_head_sha)
+    subject=$(git --no-optional-locks log -1 --pretty=%s 2>/dev/null || true)
+    files=$(git --no-optional-locks diff-tree --no-commit-id --name-only -r HEAD 2>/dev/null | wc -l | tr -d ' ' || echo "")
+    event=$(jq -nc \
+      --arg ts "$ts" --arg sid "$session_id" --arg cwd "$cwd" \
+      --arg branch "$branch" --arg commit "$commit_sha" --arg subject "$subject" --arg files "$files" \
+      '{ts:$ts, type:"git_commit", session_id:$sid, cwd:$cwd}
+       + (if $branch != "" then {branch:$branch} else {} end)
+       + (if $commit != "" then {commit:$commit} else {} end)
+       + (if $subject != "" then {subject:$subject} else {} end)
+       + (if ($files != "" and $files != "0") then {files:($files|tonumber)} else {} end)')
+    ;;
+  push)
+    event=$(jq -nc \
+      --arg ts "$ts" --arg sid "$session_id" --arg cwd "$cwd" \
+      --arg branch "$branch" --arg cmd "$cmd" \
+      '{ts:$ts, type:"git_push", session_id:$sid, cwd:$cwd, command:$cmd}
+       + (if $branch != "" then {branch:$branch} else {} end)')
+    ;;
+  checkout|switch)
+    # reflog の最新エントリから from_branch を抽出
+    # 例: "checkout: moving from main to feat/x"
+    from_branch=$(git --no-optional-locks reflog -1 --format='%gs' 2>/dev/null \
+      | sed -nE 's/.*moving from ([^ ]+) to .*/\1/p' || true)
+    event=$(jq -nc \
+      --arg ts "$ts" --arg sid "$session_id" --arg cwd "$cwd" \
+      --arg to_branch "$branch" --arg from_branch "$from_branch" --arg cmd "$cmd" \
+      '{ts:$ts, type:"git_checkout", session_id:$sid, cwd:$cwd, command:$cmd}
+       + (if $to_branch != "" then {to_branch:$to_branch} else {} end)
+       + (if $from_branch != "" then {from_branch:$from_branch} else {} end)')
+    ;;
+esac
+
+autolog_append "$event"
+exit 0

--- a/.claude/hooks/autolog-posttool.sh
+++ b/.claude/hooks/autolog-posttool.sh
@@ -24,7 +24,23 @@ subcmd=$(printf '%s' "$cmd" | grep -oE 'git +(commit|push|checkout|switch)\b' | 
 session_id=$(echo "$INPUT" | jq -r '.session_id // ""')
 cwd=$(echo "$INPUT" | jq -r '.cwd // ""')
 ts=$(autolog_ts)
+
+# 入力 cwd に移ってから git 情報を取る（cd /other && git commit のような複合コマンド対策）
+autolog_enter_cwd "$cwd"
+
 branch=$(autolog_branch)
+repo=$(autolog_repo_root)
+remote=$(autolog_repo_remote)
+
+# 共通フィールド (repo / repo_remote) を含む基底オブジェクトを作る
+common_args=(
+  --arg ts "$ts" --arg sid "$session_id" --arg cwd "$cwd"
+  --arg repo "$repo" --arg remote "$remote" --arg branch "$branch"
+)
+common_expr='{ts:$ts, session_id:$sid, cwd:$cwd}
+  + (if $repo != "" then {repo:$repo} else {} end)
+  + (if $remote != "" then {repo_remote:$remote} else {} end)
+  + (if $branch != "" then {branch:$branch} else {} end)'
 
 case "$subcmd" in
   commit)
@@ -32,20 +48,18 @@ case "$subcmd" in
     subject=$(git --no-optional-locks log -1 --pretty=%s 2>/dev/null || true)
     files=$(git --no-optional-locks diff-tree --no-commit-id --name-only -r HEAD 2>/dev/null | wc -l | tr -d ' ' || echo "")
     event=$(jq -nc \
-      --arg ts "$ts" --arg sid "$session_id" --arg cwd "$cwd" \
-      --arg branch "$branch" --arg commit "$commit_sha" --arg subject "$subject" --arg files "$files" \
-      '{ts:$ts, type:"git_commit", session_id:$sid, cwd:$cwd}
-       + (if $branch != "" then {branch:$branch} else {} end)
-       + (if $commit != "" then {commit:$commit} else {} end)
-       + (if $subject != "" then {subject:$subject} else {} end)
-       + (if ($files != "" and $files != "0") then {files:($files|tonumber)} else {} end)')
+      "${common_args[@]}" \
+      --arg commit "$commit_sha" --arg subject "$subject" --arg files "$files" \
+      "${common_expr} + {type:\"git_commit\"}
+       + (if \$commit != \"\" then {commit:\$commit} else {} end)
+       + (if \$subject != \"\" then {subject:\$subject} else {} end)
+       + (if (\$files != \"\" and \$files != \"0\") then {files:(\$files|tonumber)} else {} end)")
     ;;
   push)
     event=$(jq -nc \
-      --arg ts "$ts" --arg sid "$session_id" --arg cwd "$cwd" \
-      --arg branch "$branch" --arg cmd "$cmd" \
-      '{ts:$ts, type:"git_push", session_id:$sid, cwd:$cwd, command:$cmd}
-       + (if $branch != "" then {branch:$branch} else {} end)')
+      "${common_args[@]}" \
+      --arg cmd "$cmd" \
+      "${common_expr} + {type:\"git_push\", command:\$cmd}")
     ;;
   checkout|switch)
     # reflog の最新エントリから from_branch を抽出
@@ -53,11 +67,10 @@ case "$subcmd" in
     from_branch=$(git --no-optional-locks reflog -1 --format='%gs' 2>/dev/null \
       | sed -nE 's/.*moving from ([^ ]+) to .*/\1/p' || true)
     event=$(jq -nc \
-      --arg ts "$ts" --arg sid "$session_id" --arg cwd "$cwd" \
-      --arg to_branch "$branch" --arg from_branch "$from_branch" --arg cmd "$cmd" \
-      '{ts:$ts, type:"git_checkout", session_id:$sid, cwd:$cwd, command:$cmd}
-       + (if $to_branch != "" then {to_branch:$to_branch} else {} end)
-       + (if $from_branch != "" then {from_branch:$from_branch} else {} end)')
+      "${common_args[@]}" \
+      --arg from_branch "$from_branch" --arg cmd "$cmd" \
+      "${common_expr} + {type:\"git_checkout\", command:\$cmd, to_branch:\$branch}
+       + (if \$from_branch != \"\" then {from_branch:\$from_branch} else {} end)")
     ;;
 esac
 

--- a/.claude/hooks/autolog-session-end.sh
+++ b/.claude/hooks/autolog-session-end.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
-# Stop hook — 毎ターン終了時に session_progress として累計メトリクスを追記
+# SessionEnd hook — セッション終了時の最終スナップショットを追記
 #
-# Claude Code の Stop hook 入力は cost/duration/lines を含まない (公式ドキュメント上の
-# response_cost / response_duration / lines_generated とも実際には別構造)。
-# そこで transcript_path に書き出されているセッショントランスクリプトを jq で集計し、
-# duration / トークン使用量を取得する。
-#
-# 注意: Stop hook はセッション終了時のみではなく、各応答ターン末に発火する。
-# したがって各行は「そのターン終了時点での累積値スナップショット」として扱う。
+# Stop は各ターン末で発火するが、SessionEnd は clear/resume/logout/prompt_input_exit
+# などセッション自体の終了タイミングに発火する。end_reason と最終的な累積メトリクスを
+# まとめてここで一度だけ記録しておくと、後段の集計で「セッション末値」として
+# 確実に利用できる。
 
 set -uo pipefail
 
@@ -19,10 +16,10 @@ INPUT=$(cat)
 session_id=$(echo "$INPUT" | jq -r '.session_id // ""')
 cwd=$(echo "$INPUT" | jq -r '.cwd // ""')
 transcript_path=$(echo "$INPUT" | jq -r '.transcript_path // ""')
+end_reason=$(echo "$INPUT" | jq -r '.end_reason // .reason // ""')
 
 ts=$(autolog_ts)
 
-# transcript から累計メトリクスを取得
 metrics='{}'
 if [ -n "$transcript_path" ] && [ -f "$transcript_path" ]; then
   m=$(autolog_metrics_from_transcript "$transcript_path")
@@ -31,7 +28,6 @@ if [ -n "$transcript_path" ] && [ -f "$transcript_path" ]; then
   fi
 fi
 
-# duration_ms を計算: transcript の _first → _last
 duration_ms=""
 first_ts=$(echo "$metrics" | jq -r '._first // ""')
 last_ts=$(echo "$metrics" | jq -r '._last // ""')
@@ -43,7 +39,6 @@ if [ -n "$first_ts" ] && [ -n "$last_ts" ]; then
   fi
 fi
 
-# fallback: transcript が読めなければ session_start.ts との差分
 if [ -z "$duration_ms" ] && [ -n "$session_id" ]; then
   start_file="$(autolog_dir)/sessions/${session_id}.start"
   if [ -f "$start_file" ]; then
@@ -60,7 +55,6 @@ autolog_enter_cwd "$cwd"
 repo=$(autolog_repo_root)
 branch=$(autolog_branch)
 
-# token メトリクスから内部用 _first/_last を除去
 token_metrics=$(echo "$metrics" | jq -c 'del(._first, ._last)')
 
 event=$(jq -nc \
@@ -69,12 +63,20 @@ event=$(jq -nc \
   --arg dur "$duration_ms" \
   --arg repo "$repo" \
   --arg branch "$branch" \
+  --arg reason "$end_reason" \
   --argjson tok "$token_metrics" \
-  '{ts:$ts, type:"session_progress", session_id:$sid}
+  '{ts:$ts, type:"session_end", session_id:$sid}
    + (if $repo != "" then {repo:$repo} else {} end)
    + (if $branch != "" then {branch:$branch} else {} end)
+   + (if $reason != "" then {end_reason:$reason} else {} end)
    + (if $dur != "" then {duration_ms:($dur|tonumber)} else {} end)
    + $tok')
 
 autolog_append "$event"
+
+# セッション終了したので start ファイルをクリーンアップ
+if [ -n "$session_id" ]; then
+  rm -f "$(autolog_dir)/sessions/${session_id}.start"
+fi
+
 exit 0

--- a/.claude/hooks/autolog-session-start.sh
+++ b/.claude/hooks/autolog-session-start.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# SessionStart hook — セッション開始イベントを記録
+# 期待される hook 入力（抜粋）: { session_id, cwd, source }
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/autolog-common.sh"
+
+INPUT=$(cat)
+
+session_id=$(echo "$INPUT" | jq -r '.session_id // ""')
+cwd=$(echo "$INPUT" | jq -r '.cwd // ""')
+source_kind=$(echo "$INPUT" | jq -r '.source // ""')
+
+ts=$(autolog_ts)
+branch=$(autolog_branch)
+head=$(autolog_head_sha)
+
+autolog_init
+
+# 後段の Stop hook で duration 計算に使う start ts を保存
+if [ -n "$session_id" ]; then
+  printf '%s\n' "$ts" > "$(autolog_dir)/sessions/${session_id}.start"
+fi
+
+event=$(jq -nc \
+  --arg ts "$ts" \
+  --arg sid "$session_id" \
+  --arg cwd "$cwd" \
+  --arg branch "$branch" \
+  --arg head "$head" \
+  --arg source "$source_kind" \
+  '{ts:$ts, type:"session_start", session_id:$sid, cwd:$cwd}
+   + (if $branch != "" then {branch:$branch} else {} end)
+   + (if $head != "" then {head_sha:$head} else {} end)
+   + (if $source != "" then {source:$source} else {} end)')
+
+autolog_append "$event"
+exit 0

--- a/.claude/hooks/autolog-session-start.sh
+++ b/.claude/hooks/autolog-session-start.sh
@@ -14,8 +14,14 @@ cwd=$(echo "$INPUT" | jq -r '.cwd // ""')
 source_kind=$(echo "$INPUT" | jq -r '.source // ""')
 
 ts=$(autolog_ts)
+
+# 入力 cwd に移ってから git 情報を取る（multi-repo セッションで重要）
+autolog_enter_cwd "$cwd"
+
 branch=$(autolog_branch)
 head=$(autolog_head_sha)
+repo=$(autolog_repo_root)
+remote=$(autolog_repo_remote)
 
 autolog_init
 
@@ -31,7 +37,11 @@ event=$(jq -nc \
   --arg branch "$branch" \
   --arg head "$head" \
   --arg source "$source_kind" \
+  --arg repo "$repo" \
+  --arg remote "$remote" \
   '{ts:$ts, type:"session_start", session_id:$sid, cwd:$cwd}
+   + (if $repo != "" then {repo:$repo} else {} end)
+   + (if $remote != "" then {repo_remote:$remote} else {} end)
    + (if $branch != "" then {branch:$branch} else {} end)
    + (if $head != "" then {head_sha:$head} else {} end)
    + (if $source != "" then {source:$source} else {} end)')

--- a/.claude/hooks/autolog-stop.sh
+++ b/.claude/hooks/autolog-stop.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Stop hook — 毎ターン終了時に累積メトリクスを session_progress として追記
+# 期待される hook 入力（抜粋）: { session_id, cost: { total_duration_ms, total_cost_usd, total_lines_added, total_lines_removed } }
+# 注意: Stop hook はセッション終了時のみではなく、Claude の各応答ターン末ごとに発火する。
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/autolog-common.sh"
+
+INPUT=$(cat)
+
+session_id=$(echo "$INPUT" | jq -r '.session_id // ""')
+duration_ms=$(echo "$INPUT" | jq -r '.cost.total_duration_ms // ""')
+cost_usd=$(echo "$INPUT" | jq -r '.cost.total_cost_usd // ""')
+lines_added=$(echo "$INPUT" | jq -r '.cost.total_lines_added // ""')
+lines_removed=$(echo "$INPUT" | jq -r '.cost.total_lines_removed // ""')
+
+ts=$(autolog_ts)
+
+# duration が hook 入力に無い場合は session_start.ts との差分で計算
+if [ -z "$duration_ms" ] && [ -n "$session_id" ]; then
+  start_file="$(autolog_dir)/sessions/${session_id}.start"
+  if [ -f "$start_file" ]; then
+    start_ts=$(cat "$start_file")
+    start_epoch=$(autolog_iso_to_epoch_ms "$start_ts")
+    now_epoch=$(autolog_epoch_ms)
+    if [ -n "$start_epoch" ] && [ -n "$now_epoch" ]; then
+      duration_ms=$((now_epoch - start_epoch))
+    fi
+  fi
+fi
+
+event=$(jq -nc \
+  --arg ts "$ts" \
+  --arg sid "$session_id" \
+  --arg dur "$duration_ms" \
+  --arg cost "$cost_usd" \
+  --arg la "$lines_added" \
+  --arg lr "$lines_removed" \
+  '{ts:$ts, type:"session_progress", session_id:$sid}
+   + (if $dur != "" then {duration_ms:($dur|tonumber)} else {} end)
+   + (if $cost != "" then {cost_usd:($cost|tonumber)} else {} end)
+   + (if $la != "" then {lines_added:($la|tonumber)} else {} end)
+   + (if $lr != "" then {lines_removed:($lr|tonumber)} else {} end)')
+
+autolog_append "$event"
+exit 0

--- a/.claude/hooks/autolog-stop.sh
+++ b/.claude/hooks/autolog-stop.sh
@@ -11,6 +11,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INPUT=$(cat)
 
 session_id=$(echo "$INPUT" | jq -r '.session_id // ""')
+cwd=$(echo "$INPUT" | jq -r '.cwd // ""')
 duration_ms=$(echo "$INPUT" | jq -r '.cost.total_duration_ms // ""')
 cost_usd=$(echo "$INPUT" | jq -r '.cost.total_cost_usd // ""')
 lines_added=$(echo "$INPUT" | jq -r '.cost.total_lines_added // ""')
@@ -31,6 +32,10 @@ if [ -z "$duration_ms" ] && [ -n "$session_id" ]; then
   fi
 fi
 
+autolog_enter_cwd "$cwd"
+repo=$(autolog_repo_root)
+branch=$(autolog_branch)
+
 event=$(jq -nc \
   --arg ts "$ts" \
   --arg sid "$session_id" \
@@ -38,7 +43,11 @@ event=$(jq -nc \
   --arg cost "$cost_usd" \
   --arg la "$lines_added" \
   --arg lr "$lines_removed" \
+  --arg repo "$repo" \
+  --arg branch "$branch" \
   '{ts:$ts, type:"session_progress", session_id:$sid}
+   + (if $repo != "" then {repo:$repo} else {} end)
+   + (if $branch != "" then {branch:$branch} else {} end)
    + (if $dur != "" then {duration_ms:($dur|tonumber)} else {} end)
    + (if $cost != "" then {cost_usd:($cost|tonumber)} else {} end)
    + (if $la != "" then {lines_added:($la|tonumber)} else {} end)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,26 @@
     ]
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/autolog-session-start.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/autolog-stop.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "mcp__playwright__browser_take_screenshot",
@@ -29,6 +49,15 @@
           {
             "type": "command",
             "command": "bash .claude/hooks/open-screenshot.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/autolog-posttool.sh"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,6 +42,16 @@
         ]
       }
     ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/autolog-session-end.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "mcp__playwright__browser_take_screenshot",

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ demo/plan_output.md
 # Claude Code ワークツリー（自動生成）
 .claude/worktrees/
 
+# Claude Code hooks 自動ログ（autolog 出力）
+.claude/tmp/
+
 # プロビジョニング（講師専用、受講生には不要）
 .devcontainer/provisioning/
 dist_zips/

--- a/src/components/import/ImportModal.tsx
+++ b/src/components/import/ImportModal.tsx
@@ -10,9 +10,11 @@ import {
   pickJsonlFile,
   getRememberedSource,
   ensureReadPermission,
+  ensureWritePermission,
   rememberSource,
   readHandleAsText,
 } from '@/lib/fsAccess';
+import { purgeImportedFromJsonl } from '@/lib/autologMaintenance';
 import type { AutologSource } from '@/lib/db';
 import type { DraftTask, AutologEvent } from '@/types/import';
 import { toast } from 'sonner';
@@ -79,7 +81,7 @@ export function ImportModal({ isOpen, onClose }: ImportModalProps) {
     }
   };
 
-  /** File System Access API 経由でピック → handle を IndexedDB に保存 */
+  /** File System Access API 経由でピック → handle を IndexedDB に保存（読込 + 書込権限を一括取得） */
   const handlePickWithFsApi = async () => {
     try {
       const handle = await pickJsonlFile();
@@ -89,6 +91,9 @@ export function ImportModal({ isOpen, onClose }: ImportModalProps) {
         toast.error('読み込み権限が拒否されました');
         return;
       }
+      // 取り込み済みイベントを events.jsonl から削除するために書込権限も要求しておく
+      // 拒否されてもインポート自体は続行（削除機能だけ無効化）
+      await ensureWritePermission(handle);
       const text = await readHandleAsText(handle);
       if (ingestText(text, handle.name)) {
         await rememberSource(handle, handle.name);
@@ -107,6 +112,7 @@ export function ImportModal({ isOpen, onClose }: ImportModalProps) {
         toast.error('読み込み権限が拒否されました');
         return;
       }
+      await ensureWritePermission(handle);
       const text = await readHandleAsText(handle);
       if (ingestText(text, handle.name)) {
         await rememberSource(handle, handle.name);
@@ -114,6 +120,32 @@ export function ImportModal({ isOpen, onClose }: ImportModalProps) {
     } catch (err) {
       toast.error('前回のファイルの読み込みに失敗しました（消えた可能性があります）');
       console.error(err);
+    }
+  };
+
+  /** 取り込み成功時に events.jsonl から該当イベントを物理削除（FS API 経由、書込権限がある場合のみ） */
+  const tryPurgeFromJsonl = async (justImportedDraftKey: string) => {
+    if (!isFsAccessSupported()) return;
+    const source = await getRememberedSource();
+    if (!source?.fileHandle) return;
+    // 現時点の取り込み済み全体 + 今回追加分（useLiveQuery が再評価される前なので明示追加）
+    const allImported = new Set([...importedKeys, justImportedDraftKey]);
+    try {
+      const result = await purgeImportedFromJsonl(source.fileHandle, allImported, {
+        aggregateOpts: { since: since || undefined, until: until || undefined },
+      });
+      if (result.removedCount > 0) {
+        toast.success(
+          `events.jsonl から ${result.removedCount} 件のイベントを削除しました`
+        );
+        // 同じファイルから再集計し直すために events を更新
+        const fresh = await readHandleAsText(source.fileHandle);
+        const parsedFresh = parseEventsJsonl(fresh);
+        setEvents(parsedFresh);
+      }
+    } catch (err) {
+      // write permission denied 等は静かに諦める（IndexedDB seen-set のフォールバックで継続）
+      console.warn('events.jsonl の削減はスキップされました', err);
     }
   };
 
@@ -131,6 +163,8 @@ export function ImportModal({ isOpen, onClose }: ImportModalProps) {
         // 記録失敗は致命的ではないので toast で警告するだけ
         toast.error('取り込み記録の保存に失敗しました（タスク自体は保存済み）');
       }
+      // events.jsonl からも該当イベントを物理削除（FS API 書込権限がある場合のみ）
+      await tryPurgeFromJsonl(editingDraft.draftKey);
     }
     setEditingKey(null);
     setView('list');

--- a/src/components/import/ImportModal.tsx
+++ b/src/components/import/ImportModal.tsx
@@ -1,0 +1,285 @@
+import { useState, useMemo, useRef } from 'react';
+import { Upload, ArrowLeft, GitBranch, Clock, FileText } from 'lucide-react';
+import { Modal } from '@/components/ui/Modal';
+import { Button } from '@/components/ui/Button';
+import { TaskForm } from '@/components/task/TaskForm';
+import { parseEventsJsonl, aggregateToDrafts } from '@/lib/import';
+import type { DraftTask, AutologEvent } from '@/types/import';
+import { toast } from 'sonner';
+
+interface ImportModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+type View = 'file' | 'list' | 'edit';
+
+export function ImportModal({ isOpen, onClose }: ImportModalProps) {
+  const [view, setView] = useState<View>('file');
+  const [events, setEvents] = useState<AutologEvent[]>([]);
+  const [since, setSince] = useState<string>(() => today());
+  const [until, setUntil] = useState<string>(() => today());
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [completedKeys, setCompletedKeys] = useState<Set<string>>(new Set());
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // 期間フィルタを掛けた下書き
+  const drafts = useMemo(() => {
+    return aggregateToDrafts(events, {
+      since: since || undefined,
+      until: until || undefined,
+    });
+  }, [events, since, until]);
+
+  const remainingDrafts = drafts.filter((d) => !completedKeys.has(d.draftKey));
+  const editingDraft = drafts.find((d) => d.draftKey === editingKey);
+
+  const handleFile = async (file: File) => {
+    try {
+      const text = await file.text();
+      const parsed = parseEventsJsonl(text);
+      if (parsed.length === 0) {
+        toast.error('events.jsonl に有効なイベントが見つかりませんでした');
+        return;
+      }
+      setEvents(parsed);
+      setCompletedKeys(new Set());
+      setView('list');
+      toast.success(`${parsed.length} 件のイベントを読み込みました`);
+    } catch (err) {
+      toast.error('ファイルの読み込みに失敗しました');
+      console.error(err);
+    }
+  };
+
+  const handleStartEdit = (draftKey: string) => {
+    setEditingKey(draftKey);
+    setView('edit');
+  };
+
+  const handleSaved = () => {
+    if (editingKey) {
+      setCompletedKeys((prev) => new Set(prev).add(editingKey));
+    }
+    setEditingKey(null);
+    setView('list');
+  };
+
+  const handleBackToList = () => {
+    setEditingKey(null);
+    setView('list');
+  };
+
+  const handleReset = () => {
+    setEvents([]);
+    setCompletedKeys(new Set());
+    setEditingKey(null);
+    setView('file');
+  };
+
+  const handleCloseModal = () => {
+    // 編集中は誤操作で閉じないよう list に戻す
+    if (view === 'edit') {
+      handleBackToList();
+      return;
+    }
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleCloseModal} title="autolog インポート">
+      {view === 'file' && (
+        <FileView fileInputRef={fileInputRef} onFile={handleFile} />
+      )}
+
+      {view === 'list' && (
+        <ListView
+          drafts={drafts}
+          completedKeys={completedKeys}
+          since={since}
+          until={until}
+          onChangeSince={setSince}
+          onChangeUntil={setUntil}
+          onEdit={handleStartEdit}
+          onReset={handleReset}
+          remainingCount={remainingDrafts.length}
+        />
+      )}
+
+      {view === 'edit' && editingDraft && (
+        <EditView draft={editingDraft} onBack={handleBackToList} onSaved={handleSaved} />
+      )}
+    </Modal>
+  );
+}
+
+function FileView({
+  fileInputRef,
+  onFile,
+}: {
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  onFile: (file: File) => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-primary-600">
+        Claude Code の hooks が出力した <code className="px-1 bg-primary-100 rounded">events.jsonl</code> を選択してください。
+      </p>
+      <p className="text-xs text-primary-500">
+        既定の場所: <code className="px-1 bg-primary-100 rounded">$HOME/.claude/tmp/autolog/events.jsonl</code>
+      </p>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".jsonl,.json,application/json,application/x-ndjson,text/plain"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) onFile(file);
+          // 同じファイルの再選択を許可するため value をリセット
+          e.target.value = '';
+        }}
+      />
+      <Button onClick={() => fileInputRef.current?.click()} className="w-full" size="lg">
+        <Upload size={18} className="mr-2 inline" />
+        events.jsonl を選択
+      </Button>
+    </div>
+  );
+}
+
+function ListView({
+  drafts,
+  completedKeys,
+  since,
+  until,
+  onChangeSince,
+  onChangeUntil,
+  onEdit,
+  onReset,
+  remainingCount,
+}: {
+  drafts: DraftTask[];
+  completedKeys: Set<string>;
+  since: string;
+  until: string;
+  onChangeSince: (s: string) => void;
+  onChangeUntil: (s: string) => void;
+  onEdit: (key: string) => void;
+  onReset: () => void;
+  remainingCount: number;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-2 text-sm">
+        <label className="flex flex-col gap-1">
+          <span className="text-primary-500 text-xs">since (UTC)</span>
+          <input
+            type="date"
+            value={since}
+            onChange={(e) => onChangeSince(e.target.value)}
+            className="px-2 py-1 bg-primary-50 rounded border-0 focus:ring-2 focus:ring-accent-200 focus:bg-white"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-primary-500 text-xs">until (UTC)</span>
+          <input
+            type="date"
+            value={until}
+            onChange={(e) => onChangeUntil(e.target.value)}
+            className="px-2 py-1 bg-primary-50 rounded border-0 focus:ring-2 focus:ring-accent-200 focus:bg-white"
+          />
+        </label>
+      </div>
+
+      <div className="flex items-center justify-between text-sm">
+        <span className="text-primary-600">
+          下書き <strong>{drafts.length}</strong> 件 / 残り <strong>{remainingCount}</strong> 件
+        </span>
+        <button
+          type="button"
+          onClick={onReset}
+          className="text-xs text-primary-500 hover:text-primary-800 underline"
+        >
+          別のファイルを選ぶ
+        </button>
+      </div>
+
+      {drafts.length === 0 ? (
+        <div className="text-sm text-primary-500 text-center py-8">
+          該当期間に下書き化できるイベントが見つかりませんでした。
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {drafts.map((d) => {
+            const done = completedKeys.has(d.draftKey);
+            return (
+              <button
+                key={d.draftKey}
+                type="button"
+                onClick={() => onEdit(d.draftKey)}
+                disabled={done}
+                className={`w-full text-left p-3 rounded-lg border transition-colors ${
+                  done
+                    ? 'bg-primary-50 border-primary-100 opacity-50 cursor-not-allowed'
+                    : 'bg-white border-primary-200 hover:border-accent-400 hover:bg-accent-50'
+                }`}
+              >
+                <div className="flex items-start justify-between gap-2 mb-1">
+                  <div className="font-medium text-sm text-primary-800 line-clamp-2">
+                    {d.name}
+                  </div>
+                  {done && (
+                    <span className="text-xs text-green-600 whitespace-nowrap">✓ 取り込み済</span>
+                  )}
+                </div>
+                <div className="flex flex-wrap gap-3 text-xs text-primary-500">
+                  <span className="flex items-center gap-1">
+                    <GitBranch size={12} />
+                    {d.meta.repoName ?? '?'} / {d.meta.branch ?? 'detached'}
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <Clock size={12} />
+                    {d.duration} 分
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <FileText size={12} />
+                    {d.meta.commitCount} commits
+                  </span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EditView({
+  draft,
+  onBack,
+  onSaved,
+}: {
+  draft: DraftTask;
+  onBack: () => void;
+  onSaved: () => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <button
+        type="button"
+        onClick={onBack}
+        className="text-sm text-primary-500 hover:text-primary-800 flex items-center gap-1"
+      >
+        <ArrowLeft size={14} /> 下書き一覧に戻る
+      </button>
+      <TaskForm initialDraft={draft} onSaved={onSaved} />
+    </div>
+  );
+}
+
+/** 今日の日付（UTC、YYYY-MM-DD） */
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}

--- a/src/components/import/ImportModal.tsx
+++ b/src/components/import/ImportModal.tsx
@@ -1,9 +1,19 @@
-import { useState, useMemo, useRef } from 'react';
-import { Upload, ArrowLeft, GitBranch, Clock, FileText } from 'lucide-react';
+import { useState, useMemo, useRef, useEffect } from 'react';
+import { Upload, ArrowLeft, GitBranch, Clock, FileText, EyeOff, Eye, RefreshCw } from 'lucide-react';
 import { Modal } from '@/components/ui/Modal';
 import { Button } from '@/components/ui/Button';
 import { TaskForm } from '@/components/task/TaskForm';
 import { parseEventsJsonl, aggregateToDrafts } from '@/lib/import';
+import { useImportedDrafts } from '@/hooks/useImportedDrafts';
+import {
+  isFsAccessSupported,
+  pickJsonlFile,
+  getRememberedSource,
+  ensureReadPermission,
+  rememberSource,
+  readHandleAsText,
+} from '@/lib/fsAccess';
+import type { AutologSource } from '@/lib/db';
 import type { DraftTask, AutologEvent } from '@/types/import';
 import { toast } from 'sonner';
 
@@ -20,34 +30,89 @@ export function ImportModal({ isOpen, onClose }: ImportModalProps) {
   const [since, setSince] = useState<string>(() => today());
   const [until, setUntil] = useState<string>(() => today());
   const [editingKey, setEditingKey] = useState<string | null>(null);
-  const [completedKeys, setCompletedKeys] = useState<Set<string>>(new Set());
+  const [showImported, setShowImported] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // 取り込み済み draftKey の永続セット
+  const { importedKeys, recordImport } = useImportedDrafts();
+
   // 期間フィルタを掛けた下書き
-  const drafts = useMemo(() => {
+  const allDrafts = useMemo(() => {
     return aggregateToDrafts(events, {
       since: since || undefined,
       until: until || undefined,
     });
   }, [events, since, until]);
 
-  const remainingDrafts = drafts.filter((d) => !completedKeys.has(d.draftKey));
-  const editingDraft = drafts.find((d) => d.draftKey === editingKey);
+  // 取り込み済みを除外（showImported が true の時は全件表示）
+  const visibleDrafts = showImported
+    ? allDrafts
+    : allDrafts.filter((d) => !importedKeys.has(d.draftKey));
 
+  const remainingCount = allDrafts.filter((d) => !importedKeys.has(d.draftKey)).length;
+  const importedCount = allDrafts.length - remainingCount;
+  const editingDraft = allDrafts.find((d) => d.draftKey === editingKey);
+
+  const ingestText = (text: string, fileLabel: string): boolean => {
+    const parsed = parseEventsJsonl(text);
+    if (parsed.length === 0) {
+      toast.error(`${fileLabel} に有効なイベントが見つかりませんでした`);
+      return false;
+    }
+    setEvents(parsed);
+    setView('list');
+    toast.success(`${parsed.length} 件のイベントを読み込みました`);
+    return true;
+  };
+
+  /** 通常の <input type=file> 経由（FileSystemFileHandle 取れない） */
   const handleFile = async (file: File) => {
     try {
       const text = await file.text();
-      const parsed = parseEventsJsonl(text);
-      if (parsed.length === 0) {
-        toast.error('events.jsonl に有効なイベントが見つかりませんでした');
-        return;
+      if (ingestText(text, file.name)) {
+        // handle 無しでも filename だけは記憶（次回フォールバック表示用）
+        await rememberSource(null, file.name);
       }
-      setEvents(parsed);
-      setCompletedKeys(new Set());
-      setView('list');
-      toast.success(`${parsed.length} 件のイベントを読み込みました`);
     } catch (err) {
       toast.error('ファイルの読み込みに失敗しました');
+      console.error(err);
+    }
+  };
+
+  /** File System Access API 経由でピック → handle を IndexedDB に保存 */
+  const handlePickWithFsApi = async () => {
+    try {
+      const handle = await pickJsonlFile();
+      if (!handle) return; // キャンセル
+      const ok = await ensureReadPermission(handle);
+      if (!ok) {
+        toast.error('読み込み権限が拒否されました');
+        return;
+      }
+      const text = await readHandleAsText(handle);
+      if (ingestText(text, handle.name)) {
+        await rememberSource(handle, handle.name);
+      }
+    } catch (err) {
+      toast.error('ファイルの読み込みに失敗しました');
+      console.error(err);
+    }
+  };
+
+  /** 前回のハンドルから一発で再読込 */
+  const handleReadSaved = async (handle: FileSystemFileHandle) => {
+    try {
+      const ok = await ensureReadPermission(handle);
+      if (!ok) {
+        toast.error('読み込み権限が拒否されました');
+        return;
+      }
+      const text = await readHandleAsText(handle);
+      if (ingestText(text, handle.name)) {
+        await rememberSource(handle, handle.name);
+      }
+    } catch (err) {
+      toast.error('前回のファイルの読み込みに失敗しました（消えた可能性があります）');
       console.error(err);
     }
   };
@@ -57,9 +122,15 @@ export function ImportModal({ isOpen, onClose }: ImportModalProps) {
     setView('edit');
   };
 
-  const handleSaved = () => {
-    if (editingKey) {
-      setCompletedKeys((prev) => new Set(prev).add(editingKey));
+  const handleSaved = async (taskId: string) => {
+    if (editingDraft) {
+      try {
+        await recordImport(editingDraft, taskId);
+      } catch (err) {
+        console.error('取り込み済み記録に失敗しました', err);
+        // 記録失敗は致命的ではないので toast で警告するだけ
+        toast.error('取り込み記録の保存に失敗しました（タスク自体は保存済み）');
+      }
     }
     setEditingKey(null);
     setView('list');
@@ -72,7 +143,6 @@ export function ImportModal({ isOpen, onClose }: ImportModalProps) {
 
   const handleReset = () => {
     setEvents([]);
-    setCompletedKeys(new Set());
     setEditingKey(null);
     setView('file');
   };
@@ -89,20 +159,28 @@ export function ImportModal({ isOpen, onClose }: ImportModalProps) {
   return (
     <Modal isOpen={isOpen} onClose={handleCloseModal} title="autolog インポート">
       {view === 'file' && (
-        <FileView fileInputRef={fileInputRef} onFile={handleFile} />
+        <FileView
+          fileInputRef={fileInputRef}
+          onFile={handleFile}
+          onPickWithFsApi={handlePickWithFsApi}
+          onReadSaved={handleReadSaved}
+        />
       )}
 
       {view === 'list' && (
         <ListView
-          drafts={drafts}
-          completedKeys={completedKeys}
+          drafts={visibleDrafts}
+          importedKeys={importedKeys}
           since={since}
           until={until}
           onChangeSince={setSince}
           onChangeUntil={setUntil}
           onEdit={handleStartEdit}
           onReset={handleReset}
-          remainingCount={remainingDrafts.length}
+          remainingCount={remainingCount}
+          importedCount={importedCount}
+          showImported={showImported}
+          onToggleShowImported={() => setShowImported((v) => !v)}
         />
       )}
 
@@ -116,10 +194,21 @@ export function ImportModal({ isOpen, onClose }: ImportModalProps) {
 function FileView({
   fileInputRef,
   onFile,
+  onPickWithFsApi,
+  onReadSaved,
 }: {
   fileInputRef: React.RefObject<HTMLInputElement | null>;
   onFile: (file: File) => void;
+  onPickWithFsApi: () => void;
+  onReadSaved: (handle: FileSystemFileHandle) => void;
 }) {
+  const [saved, setSaved] = useState<AutologSource | undefined>();
+  const fsSupported = isFsAccessSupported();
+
+  useEffect(() => {
+    getRememberedSource().then(setSaved);
+  }, []);
+
   return (
     <div className="space-y-4">
       <p className="text-sm text-primary-600">
@@ -128,6 +217,35 @@ function FileView({
       <p className="text-xs text-primary-500">
         既定の場所: <code className="px-1 bg-primary-100 rounded">$HOME/.claude/tmp/autolog/events.jsonl</code>
       </p>
+
+      {/* 前回のソース情報 */}
+      {saved && (
+        <div className="p-3 bg-primary-50 rounded-lg text-xs space-y-1">
+          <div className="flex items-center justify-between">
+            <span className="text-primary-500">前回:</span>
+            <span className="font-mono text-primary-700">{saved.fileName}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-primary-500">最終読込:</span>
+            <span className="text-primary-700">{formatRelativeTime(saved.lastReadAt)}</span>
+          </div>
+        </div>
+      )}
+
+      {/* 再読込ボタン（前回 handle が残っている時のみ） */}
+      {saved?.fileHandle && (
+        <Button
+          onClick={() => onReadSaved(saved.fileHandle!)}
+          className="w-full"
+          size="lg"
+          variant="primary"
+        >
+          <RefreshCw size={18} className="mr-2 inline" />
+          前回のファイルから再読込
+        </Button>
+      )}
+
+      {/* 新規ピック */}
       <input
         ref={fileInputRef}
         type="file"
@@ -136,21 +254,42 @@ function FileView({
         onChange={(e) => {
           const file = e.target.files?.[0];
           if (file) onFile(file);
-          // 同じファイルの再選択を許可するため value をリセット
           e.target.value = '';
         }}
       />
-      <Button onClick={() => fileInputRef.current?.click()} className="w-full" size="lg">
+      <Button
+        onClick={() => (fsSupported ? onPickWithFsApi() : fileInputRef.current?.click())}
+        className="w-full"
+        size="lg"
+        variant={saved?.fileHandle ? 'secondary' : 'primary'}
+      >
         <Upload size={18} className="mr-2 inline" />
-        events.jsonl を選択
+        {saved?.fileHandle ? '別のファイルを選ぶ' : 'events.jsonl を選択'}
       </Button>
+
+      {!fsSupported && (
+        <p className="text-xs text-primary-400">
+          このブラウザは File System Access API 非対応のため、毎回ファイル選択が必要です（Chrome / Edge を推奨）。
+        </p>
+      )}
     </div>
   );
 }
 
+function formatRelativeTime(date: Date): string {
+  const ms = Date.now() - new Date(date).getTime();
+  const min = Math.floor(ms / 60000);
+  if (min < 1) return 'たった今';
+  if (min < 60) return `${min} 分前`;
+  const h = Math.floor(min / 60);
+  if (h < 24) return `${h} 時間前`;
+  const d = Math.floor(h / 24);
+  return `${d} 日前`;
+}
+
 function ListView({
   drafts,
-  completedKeys,
+  importedKeys,
   since,
   until,
   onChangeSince,
@@ -158,9 +297,12 @@ function ListView({
   onEdit,
   onReset,
   remainingCount,
+  importedCount,
+  showImported,
+  onToggleShowImported,
 }: {
   drafts: DraftTask[];
-  completedKeys: Set<string>;
+  importedKeys: Set<string>;
   since: string;
   until: string;
   onChangeSince: (s: string) => void;
@@ -168,12 +310,15 @@ function ListView({
   onEdit: (key: string) => void;
   onReset: () => void;
   remainingCount: number;
+  importedCount: number;
+  showImported: boolean;
+  onToggleShowImported: () => void;
 }) {
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-2 gap-2 text-sm">
         <label className="flex flex-col gap-1">
-          <span className="text-primary-500 text-xs">since (UTC)</span>
+          <span className="text-primary-500 text-xs">since (JST)</span>
           <input
             type="date"
             value={since}
@@ -182,7 +327,7 @@ function ListView({
           />
         </label>
         <label className="flex flex-col gap-1">
-          <span className="text-primary-500 text-xs">until (UTC)</span>
+          <span className="text-primary-500 text-xs">until (JST)</span>
           <input
             type="date"
             value={until}
@@ -194,30 +339,48 @@ function ListView({
 
       <div className="flex items-center justify-between text-sm">
         <span className="text-primary-600">
-          下書き <strong>{drafts.length}</strong> 件 / 残り <strong>{remainingCount}</strong> 件
+          残り <strong>{remainingCount}</strong> 件
+          {importedCount > 0 && (
+            <span className="text-primary-400 ml-1">／ 取り込み済 {importedCount} 件</span>
+          )}
         </span>
-        <button
-          type="button"
-          onClick={onReset}
-          className="text-xs text-primary-500 hover:text-primary-800 underline"
-        >
-          別のファイルを選ぶ
-        </button>
+        <div className="flex items-center gap-3">
+          {importedCount > 0 && (
+            <button
+              type="button"
+              onClick={onToggleShowImported}
+              className="text-xs text-primary-500 hover:text-primary-800 flex items-center gap-1"
+              title="取り込み済みの再表示は通常不要。確認用"
+            >
+              {showImported ? <EyeOff size={12} /> : <Eye size={12} />}
+              {showImported ? '取り込み済みを隠す' : '取り込み済みも表示'}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onReset}
+            className="text-xs text-primary-500 hover:text-primary-800 underline"
+          >
+            別のファイルを選ぶ
+          </button>
+        </div>
       </div>
 
       {drafts.length === 0 ? (
         <div className="text-sm text-primary-500 text-center py-8">
-          該当期間に下書き化できるイベントが見つかりませんでした。
+          {remainingCount === 0 && importedCount > 0
+            ? '該当期間の下書きはすべて取り込み済みです 🎉'
+            : '該当期間に下書き化できるイベントが見つかりませんでした。'}
         </div>
       ) : (
         <div className="space-y-2">
           {drafts.map((d) => {
-            const done = completedKeys.has(d.draftKey);
+            const done = importedKeys.has(d.draftKey);
             return (
               <button
                 key={d.draftKey}
                 type="button"
-                onClick={() => onEdit(d.draftKey)}
+                onClick={() => !done && onEdit(d.draftKey)}
                 disabled={done}
                 className={`w-full text-left p-3 rounded-lg border transition-colors ${
                   done
@@ -263,7 +426,7 @@ function EditView({
 }: {
   draft: DraftTask;
   onBack: () => void;
-  onSaved: () => void;
+  onSaved: (taskId: string) => void;
 }) {
   return (
     <div className="space-y-3">
@@ -279,7 +442,8 @@ function EditView({
   );
 }
 
-/** 今日の日付（UTC、YYYY-MM-DD） */
+/** 今日の日付（JST、YYYY-MM-DD）— aggregateToDrafts が JST 解釈なので合わせる */
 function today(): string {
-  return new Date().toISOString().slice(0, 10);
+  const jstMs = Date.now() + 9 * 60 * 60 * 1000;
+  return new Date(jstMs).toISOString().slice(0, 10);
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,10 +1,11 @@
-import { List, BarChart3, Settings } from 'lucide-react';
+import { List, BarChart3, Settings, Upload } from 'lucide-react';
 import type { ComponentType } from 'react';
 
 interface HeaderProps {
   onTaskListClick?: () => void;
   onStatsClick?: () => void;
   onSettingsClick?: () => void;
+  onImportClick?: () => void;
 }
 
 interface IconButtonProps {
@@ -34,11 +35,17 @@ function IconButton({ label, icon: Icon, onClick }: IconButtonProps) {
   );
 }
 
-export function Header({ onTaskListClick, onStatsClick, onSettingsClick }: HeaderProps) {
+export function Header({
+  onTaskListClick,
+  onStatsClick,
+  onSettingsClick,
+  onImportClick,
+}: HeaderProps) {
   return (
     <div className="flex justify-between items-center mb-4">
       <h1 className="text-xl font-bold text-primary-800">InsightLog</h1>
       <div className="flex gap-2">
+        <IconButton label="autolog インポート" icon={Upload} onClick={onImportClick} />
         <IconButton label="タスク一覧" icon={List} onClick={onTaskListClick} />
         <IconButton label="統計" icon={BarChart3} onClick={onStatsClick} />
         <IconButton label="設定" icon={Settings} onClick={onSettingsClick} />

--- a/src/components/task/TaskForm.tsx
+++ b/src/components/task/TaskForm.tsx
@@ -9,39 +9,56 @@ import { useSettings } from '@/hooks/useSettings';
 import { TASK_CATEGORIES } from '@/constants/categories';
 import { AI_TOOLS, AI_NOT_USED } from '@/constants/aiTools';
 import type { DraftTask } from '@/types/import';
+import type { Task } from '@/types/task';
 import { toast } from 'sonner';
 import { secondsToMinutes } from '@/lib/time';
 
 interface TaskFormProps {
-  /** インポート由来の初期値。指定時は draft mode となり、必須項目に AI なし所要時間が追加される */
+  /** インポート由来の初期値。指定時は draft mode（新規追加・AI 関連必須） */
   initialDraft?: DraftTask;
-  /** 保存成功時のコールバック（draft mode のインポート画面で次の下書きへ遷移するのに使う） */
-  onSaved?: () => void;
-  /** 送信ボタンのラベル。未指定なら「タスクを記録」 */
+  /** 既存タスクの初期値。指定時は edit mode（更新） */
+  initialTask?: Task;
+  /** 保存成功時のコールバック（追加 or 更新された Task の id を渡す） */
+  onSaved?: (taskId: string) => void;
+  /** 送信ボタンのラベル。未指定なら mode に応じたデフォルト */
   submitLabel?: string;
 }
 
-export function TaskForm({ initialDraft, onSaved, submitLabel }: TaskFormProps = {}) {
-  const { addTask } = useTasks();
+export function TaskForm({ initialDraft, initialTask, onSaved, submitLabel }: TaskFormProps = {}) {
+  const { addTask, updateTask } = useTasks();
   const { getTodaySessions } = useSessions();
   const { settings, updateSettings } = useSettings();
 
   const isDraftMode = initialDraft !== undefined;
+  const isEditMode = initialTask !== undefined;
 
-  const [name, setName] = useState(initialDraft?.name ?? '');
-  const [taskUrl, setTaskUrl] = useState(initialDraft?.taskUrl ?? '');
-  const [selectedAITools, setSelectedAITools] = useState<string[]>([]);
+  // 初期値は edit mode > draft mode > 空 の優先順
+  const [name, setName] = useState(initialTask?.name ?? initialDraft?.name ?? '');
+  const [taskUrl, setTaskUrl] = useState(initialTask?.taskUrl ?? initialDraft?.taskUrl ?? '');
+  const [selectedAITools, setSelectedAITools] = useState<string[]>(initialTask?.aiToolsUsed ?? []);
   const [duration, setDuration] = useState(
-    initialDraft?.duration !== undefined ? String(initialDraft.duration) : ''
+    initialTask?.duration !== undefined
+      ? String(initialTask.duration)
+      : initialDraft?.duration !== undefined
+      ? String(initialDraft.duration)
+      : ''
   );
-  const [timeMinutesNoAi, setTimeMinutesNoAi] = useState('');
+  const [timeMinutesNoAi, setTimeMinutesNoAi] = useState(
+    initialTask?.timeMinutesNoAi !== undefined ? String(initialTask.timeMinutesNoAi) : ''
+  );
   const [reworkCount, setReworkCount] = useState(
-    initialDraft?.reworkCount !== undefined ? String(initialDraft.reworkCount) : '0'
+    initialTask?.reworkCount !== undefined
+      ? String(initialTask.reworkCount)
+      : initialDraft?.reworkCount !== undefined
+      ? String(initialDraft.reworkCount)
+      : '0'
   );
-  const [selectedCategories, setSelectedCategories] = useState<string[]>(initialDraft?.category ?? []);
+  const [selectedCategories, setSelectedCategories] = useState<string[]>(
+    initialTask?.category ?? initialDraft?.category ?? []
+  );
   const [customCategory, setCustomCategory] = useState('');
   const [showCustomCategoryInput, setShowCustomCategoryInput] = useState(false);
-  const [notes, setNotes] = useState(initialDraft?.notes ?? '');
+  const [notes, setNotes] = useState(initialTask?.notes ?? initialDraft?.notes ?? '');
 
   // 全カテゴリ（固定 + カスタム）
   const allCategories = [...TASK_CATEGORIES, ...(settings.customCategories || [])];
@@ -49,9 +66,9 @@ export function TaskForm({ initialDraft, onSaved, submitLabel }: TaskFormProps =
   // 「AI未使用」が選択されているか
   const isAINotUsed = selectedAITools.includes(AI_NOT_USED);
 
-  // 作業時間を自動計算（draft mode では autolog 由来の値を尊重するのでスキップ）
+  // 作業時間を自動計算（draft / edit mode では入力値を尊重するのでスキップ）
   useEffect(() => {
-    if (isDraftMode) return;
+    if (isDraftMode || isEditMode) return;
 
     const fetchTodayDuration = async () => {
       const sessions = await getTodaySessions();
@@ -68,7 +85,7 @@ export function TaskForm({ initialDraft, onSaved, submitLabel }: TaskFormProps =
 
     fetchTodayDuration();
   // eslint-disable-next-line react-hooks/exhaustive-deps -- durationの変更で再取得は不要
-  }, [getTodaySessions, isDraftMode]);
+  }, [getTodaySessions, isDraftMode, isEditMode]);
 
   const handleCategoryToggle = (category: string) => {
     setSelectedCategories((prev) =>
@@ -176,7 +193,7 @@ export function TaskForm({ initialDraft, onSaved, submitLabel }: TaskFormProps =
     }
 
     try {
-      await addTask({
+      const payload = {
         name: name.trim(),
         taskUrl: taskUrl.trim() || undefined,
         aiToolsUsed: selectedAITools,
@@ -185,13 +202,21 @@ export function TaskForm({ initialDraft, onSaved, submitLabel }: TaskFormProps =
         reworkCount: Number(reworkCount),
         category: selectedCategories,
         notes: notes.trim(),
-      });
+      };
 
+      if (isEditMode && initialTask) {
+        await updateTask(initialTask.id, payload);
+        toast.success('タスクを更新しました');
+        onSaved?.(initialTask.id);
+        return;
+      }
+
+      const taskId = await addTask(payload);
       toast.success('タスクを記録しました');
 
       if (isDraftMode) {
         // 下書きフローでは親 (ImportModal) が次の状態に遷移させる
-        onSaved?.();
+        onSaved?.(taskId);
       } else {
         // 通常フローはフォームリセット
         setName('');
@@ -203,10 +228,10 @@ export function TaskForm({ initialDraft, onSaved, submitLabel }: TaskFormProps =
         setSelectedCategories([]);
         setShowCustomCategoryInput(false);
         setNotes('');
-        onSaved?.();
+        onSaved?.(taskId);
       }
     } catch (error) {
-      toast.error('タスクの記録に失敗しました');
+      toast.error(isEditMode ? 'タスクの更新に失敗しました' : 'タスクの記録に失敗しました');
       console.error(error);
     }
   };
@@ -214,7 +239,11 @@ export function TaskForm({ initialDraft, onSaved, submitLabel }: TaskFormProps =
   return (
     <Card>
       <h2 className="font-bold text-primary-800 mb-4">
-        {isDraftMode ? 'autolog からのインポート（下書き）' : 'タスク記録'}
+        {isEditMode
+          ? 'タスクを編集'
+          : isDraftMode
+          ? 'autolog からのインポート（下書き）'
+          : 'タスク記録'}
       </h2>
 
       {/* draft mode: autolog メタ情報のサマリー */}
@@ -419,7 +448,12 @@ export function TaskForm({ initialDraft, onSaved, submitLabel }: TaskFormProps =
 
         {/* 保存ボタン */}
         <Button type="submit" className="w-full" size="lg">
-          {submitLabel ?? (isDraftMode ? 'この下書きを確定' : 'タスクを記録')}
+          {submitLabel ??
+            (isEditMode
+              ? '変更を保存'
+              : isDraftMode
+              ? 'この下書きを確定'
+              : 'タスクを記録')}
         </Button>
       </form>
     </Card>

--- a/src/components/task/TaskForm.tsx
+++ b/src/components/task/TaskForm.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Clock, RotateCcw, Link as LinkIcon, Info, X } from 'lucide-react';
+import { Clock, RotateCcw, Link as LinkIcon, Info, X, FileText, GitBranch } from 'lucide-react';
 import { Card } from '@/components/ui/Card';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
@@ -8,24 +8,40 @@ import { useSessions } from '@/hooks/useSessions';
 import { useSettings } from '@/hooks/useSettings';
 import { TASK_CATEGORIES } from '@/constants/categories';
 import { AI_TOOLS, AI_NOT_USED } from '@/constants/aiTools';
+import type { DraftTask } from '@/types/import';
 import { toast } from 'sonner';
 import { secondsToMinutes } from '@/lib/time';
 
-export function TaskForm() {
+interface TaskFormProps {
+  /** インポート由来の初期値。指定時は draft mode となり、必須項目に AI なし所要時間が追加される */
+  initialDraft?: DraftTask;
+  /** 保存成功時のコールバック（draft mode のインポート画面で次の下書きへ遷移するのに使う） */
+  onSaved?: () => void;
+  /** 送信ボタンのラベル。未指定なら「タスクを記録」 */
+  submitLabel?: string;
+}
+
+export function TaskForm({ initialDraft, onSaved, submitLabel }: TaskFormProps = {}) {
   const { addTask } = useTasks();
   const { getTodaySessions } = useSessions();
   const { settings, updateSettings } = useSettings();
 
-  const [name, setName] = useState('');
-  const [taskUrl, setTaskUrl] = useState('');
+  const isDraftMode = initialDraft !== undefined;
+
+  const [name, setName] = useState(initialDraft?.name ?? '');
+  const [taskUrl, setTaskUrl] = useState(initialDraft?.taskUrl ?? '');
   const [selectedAITools, setSelectedAITools] = useState<string[]>([]);
-  const [duration, setDuration] = useState('');
+  const [duration, setDuration] = useState(
+    initialDraft?.duration !== undefined ? String(initialDraft.duration) : ''
+  );
   const [timeMinutesNoAi, setTimeMinutesNoAi] = useState('');
-  const [reworkCount, setReworkCount] = useState('0');
-  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+  const [reworkCount, setReworkCount] = useState(
+    initialDraft?.reworkCount !== undefined ? String(initialDraft.reworkCount) : '0'
+  );
+  const [selectedCategories, setSelectedCategories] = useState<string[]>(initialDraft?.category ?? []);
   const [customCategory, setCustomCategory] = useState('');
   const [showCustomCategoryInput, setShowCustomCategoryInput] = useState(false);
-  const [notes, setNotes] = useState('');
+  const [notes, setNotes] = useState(initialDraft?.notes ?? '');
 
   // 全カテゴリ（固定 + カスタム）
   const allCategories = [...TASK_CATEGORIES, ...(settings.customCategories || [])];
@@ -33,8 +49,10 @@ export function TaskForm() {
   // 「AI未使用」が選択されているか
   const isAINotUsed = selectedAITools.includes(AI_NOT_USED);
 
-  // 作業時間を自動計算
+  // 作業時間を自動計算（draft mode では autolog 由来の値を尊重するのでスキップ）
   useEffect(() => {
+    if (isDraftMode) return;
+
     const fetchTodayDuration = async () => {
       const sessions = await getTodaySessions();
       const workSessions = sessions.filter(
@@ -50,7 +68,7 @@ export function TaskForm() {
 
     fetchTodayDuration();
   // eslint-disable-next-line react-hooks/exhaustive-deps -- durationの変更で再取得は不要
-  }, [getTodaySessions]);
+  }, [getTodaySessions, isDraftMode]);
 
   const handleCategoryToggle = (category: string) => {
     setSelectedCategories((prev) =>
@@ -151,6 +169,12 @@ export function TaskForm() {
       return;
     }
 
+    // draft mode では「AI なし所要時間」も必須にする（インポート目的そのものなので）
+    if (isDraftMode && (!timeMinutesNoAi || Number(timeMinutesNoAi) <= 0)) {
+      toast.error('AI未利用時の所要時間を入力してください');
+      return;
+    }
+
     try {
       await addTask({
         name: name.trim(),
@@ -165,16 +189,22 @@ export function TaskForm() {
 
       toast.success('タスクを記録しました');
 
-      // フォームをリセット
-      setName('');
-      setTaskUrl('');
-      setSelectedAITools([]);
-      setDuration('');
-      setTimeMinutesNoAi('');
-      setReworkCount('0');
-      setSelectedCategories([]);
-      setShowCustomCategoryInput(false);
-      setNotes('');
+      if (isDraftMode) {
+        // 下書きフローでは親 (ImportModal) が次の状態に遷移させる
+        onSaved?.();
+      } else {
+        // 通常フローはフォームリセット
+        setName('');
+        setTaskUrl('');
+        setSelectedAITools([]);
+        setDuration('');
+        setTimeMinutesNoAi('');
+        setReworkCount('0');
+        setSelectedCategories([]);
+        setShowCustomCategoryInput(false);
+        setNotes('');
+        onSaved?.();
+      }
     } catch (error) {
       toast.error('タスクの記録に失敗しました');
       console.error(error);
@@ -183,7 +213,33 @@ export function TaskForm() {
 
   return (
     <Card>
-      <h2 className="font-bold text-primary-800 mb-4">タスク記録</h2>
+      <h2 className="font-bold text-primary-800 mb-4">
+        {isDraftMode ? 'autolog からのインポート（下書き）' : 'タスク記録'}
+      </h2>
+
+      {/* draft mode: autolog メタ情報のサマリー */}
+      {isDraftMode && initialDraft?.meta && (
+        <div className="mb-4 p-3 bg-accent-50 rounded-lg text-xs text-primary-700 space-y-1">
+          <div className="flex items-center gap-2">
+            <GitBranch size={14} className="text-primary-500" />
+            <span className="font-mono">
+              {initialDraft.meta.repoName ?? '(unknown)'} / {initialDraft.meta.branch ?? '(detached)'}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <FileText size={14} className="text-primary-500" />
+            <span>
+              {initialDraft.meta.commitCount} コミット ・ セッション {initialDraft.meta.sessionIds.length} 件
+              {initialDraft.meta.costUsd !== undefined && (
+                <span className="ml-2">・ Claude コスト ${initialDraft.meta.costUsd.toFixed(3)}</span>
+              )}
+            </span>
+          </div>
+          <div className="text-primary-500 text-[10px]">
+            {initialDraft.meta.firstTs} 〜 {initialDraft.meta.lastTs}
+          </div>
+        </div>
+      )}
 
       <form onSubmit={handleSubmit} className="space-y-4">
         {/* タスク名 */}
@@ -363,7 +419,7 @@ export function TaskForm() {
 
         {/* 保存ボタン */}
         <Button type="submit" className="w-full" size="lg">
-          タスクを記録
+          {submitLabel ?? (isDraftMode ? 'この下書きを確定' : 'タスクを記録')}
         </Button>
       </form>
     </Card>

--- a/src/components/task/TaskItem.tsx
+++ b/src/components/task/TaskItem.tsx
@@ -1,4 +1,4 @@
-import { Sparkles, ExternalLink, Trash2, TrendingDown } from 'lucide-react';
+import { Sparkles, ExternalLink, Trash2, TrendingDown, Pencil } from 'lucide-react';
 import type { Task } from '@/types/task';
 import { Badge } from '@/components/ui/Badge';
 import { formatMinutes } from '@/lib/time';
@@ -7,6 +7,7 @@ import { isAiUsed } from '@/lib/task-helpers';
 interface TaskItemProps {
   task: Task;
   onDelete?: (id: string) => void;
+  onEdit?: (task: Task) => void;
 }
 
 function calcReductionPercent(task: Task): number | null {
@@ -14,7 +15,7 @@ function calcReductionPercent(task: Task): number | null {
   return Math.round((1 - task.duration / task.timeMinutesNoAi) * 100);
 }
 
-export function TaskItem({ task, onDelete }: TaskItemProps) {
+export function TaskItem({ task, onDelete, onEdit }: TaskItemProps) {
   const reduction = calcReductionPercent(task);
 
   return (
@@ -46,6 +47,15 @@ export function TaskItem({ task, onDelete }: TaskItemProps) {
               <TrendingDown size={12} />
               {reduction > 0 ? `-${reduction}%` : `+${Math.abs(reduction)}%`}
             </span>
+          )}
+          {onEdit && (
+            <button
+              onClick={() => onEdit(task)}
+              className="p-1 text-primary-400 hover:text-accent-600 hover:bg-accent-50 rounded transition-colors"
+              title="編集"
+            >
+              <Pencil size={14} />
+            </button>
           )}
           {onDelete && (
             <button

--- a/src/components/task/TaskList.tsx
+++ b/src/components/task/TaskList.tsx
@@ -1,6 +1,10 @@
+import { useState } from 'react';
+import { ArrowLeft } from 'lucide-react';
 import { Modal } from '@/components/ui/Modal';
 import { TaskItem } from './TaskItem';
+import { TaskForm } from './TaskForm';
 import { useTasks } from '@/hooks/useTasks';
+import type { Task } from '@/types/task';
 import { toast } from 'sonner';
 
 interface TaskListProps {
@@ -10,6 +14,7 @@ interface TaskListProps {
 
 export function TaskList({ isOpen, onClose }: TaskListProps) {
   const { tasks, deleteTask } = useTasks();
+  const [editingTask, setEditingTask] = useState<Task | null>(null);
 
   const handleDelete = async (id: string) => {
     try {
@@ -20,16 +25,48 @@ export function TaskList({ isOpen, onClose }: TaskListProps) {
     }
   };
 
+  const handleEdit = (task: Task) => {
+    setEditingTask(task);
+  };
+
+  const handleEditDone = () => {
+    setEditingTask(null);
+  };
+
+  const handleCloseModal = () => {
+    // 編集中はリストに戻すだけ
+    if (editingTask) {
+      setEditingTask(null);
+      return;
+    }
+    onClose();
+  };
+
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title="タスク一覧">
-      {tasks.length === 0 ? (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleCloseModal}
+      title={editingTask ? 'タスクを編集' : 'タスク一覧'}
+    >
+      {editingTask ? (
+        <div className="space-y-3">
+          <button
+            type="button"
+            onClick={handleEditDone}
+            className="text-sm text-primary-500 hover:text-primary-800 flex items-center gap-1"
+          >
+            <ArrowLeft size={14} /> 一覧に戻る
+          </button>
+          <TaskForm initialTask={editingTask} onSaved={handleEditDone} />
+        </div>
+      ) : tasks.length === 0 ? (
         <div className="text-center py-8 text-primary-400">
           <p>まだタスクが記録されていません</p>
         </div>
       ) : (
         <div>
           {tasks.map((task) => (
-            <TaskItem key={task.id} task={task} onDelete={handleDelete} />
+            <TaskItem key={task.id} task={task} onDelete={handleDelete} onEdit={handleEdit} />
           ))}
         </div>
       )}

--- a/src/hooks/useImportedDrafts.ts
+++ b/src/hooks/useImportedDrafts.ts
@@ -1,0 +1,40 @@
+import { useLiveQuery } from 'dexie-react-hooks';
+import { db, type ImportedDraft } from '@/lib/db';
+import type { DraftTask } from '@/types/import';
+
+/**
+ * autolog インポートで取り込み済みの draftKey を追跡するフック。
+ * 同じ events.jsonl を再インポートしても重複が作られないようにする。
+ */
+export function useImportedDrafts() {
+  const imported = useLiveQuery(() => db.importedDrafts.toArray());
+
+  /** 取り込み済み draftKey のセット（O(1) ルックアップ用） */
+  const importedKeys = new Set((imported ?? []).map((r) => r.draftKey));
+
+  /** 取り込み実施を記録する */
+  const recordImport = async (draft: DraftTask, taskId: string): Promise<void> => {
+    const record: ImportedDraft = {
+      draftKey: draft.draftKey,
+      taskId,
+      importedAt: new Date(),
+      name: draft.name,
+      repo: draft.meta.repo,
+      branch: draft.meta.branch,
+      jstDate: draft.meta.jstDate,
+    };
+    await db.importedDrafts.put(record);
+  };
+
+  /** taskId に紐づく取り込み記録を削除（タスク削除時のカスケード用） */
+  const removeByTaskId = async (taskId: string): Promise<void> => {
+    await db.importedDrafts.where('taskId').equals(taskId).delete();
+  };
+
+  return {
+    imported: imported ?? [],
+    importedKeys,
+    recordImport,
+    removeByTaskId,
+  };
+}

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -35,10 +35,15 @@ export function useTasks() {
   };
 
   /**
-   * タスクを削除
+   * タスクを削除（autolog の取り込み記録もカスケード削除する）
    */
   const deleteTask = async (id: string): Promise<void> => {
-    await db.tasks.delete(id);
+    await db.transaction('rw', db.tasks, db.importedDrafts, async () => {
+      await db.tasks.delete(id);
+      // 取り込み由来のタスクなら importedDrafts 側のエントリも消す
+      // → 同じ events.jsonl を再インポートする時にまた候補に出るようになる
+      await db.importedDrafts.where('taskId').equals(id).delete();
+    });
   };
 
   /**

--- a/src/lib/autologMaintenance.ts
+++ b/src/lib/autologMaintenance.ts
@@ -1,0 +1,93 @@
+// events.jsonl の物理メンテナンス。
+// File System Access API で取った handle を使い、取り込み済み draftKey に紐づく
+// events を削除する。race-safe（書き戻し直前に concurrent append 部分を取り直す）。
+
+import { parseEventsJsonl, eventsByDraftKey } from './import';
+import { readHandleAsText, writeHandleText, ensureWritePermission } from './fsAccess';
+import type { AggregateOptions, AutologEvent } from '@/types/import';
+
+/**
+ * importedDraftKeys に紐づくイベントを除外したリストを返す（純粋関数）。
+ * 取り込み済みかどうかの判定は eventsByDraftKey 経由で行う。
+ */
+export function filterOutImported(
+  events: AutologEvent[],
+  importedDraftKeys: Set<string>,
+  aggregateOpts: AggregateOptions = {}
+): { kept: AutologEvent[]; removedCount: number } {
+  if (importedDraftKeys.size === 0) {
+    return { kept: events.slice(), removedCount: 0 };
+  }
+  const map = eventsByDraftKey(events, aggregateOpts);
+  const kept = events.filter((e) => {
+    const k = map.get(e);
+    return !k || !importedDraftKeys.has(k);
+  });
+  return { kept, removedCount: events.length - kept.length };
+}
+
+export interface PurgeResult {
+  removedCount: number;
+  preservedCount: number;
+  appendedDuringPurge: number;
+}
+
+export interface PurgeOptions {
+  /** aggregateToDrafts と同じグルーピング設定（取り込み時の opts と合わせる必要がある） */
+  aggregateOpts?: AggregateOptions;
+}
+
+/**
+ * events.jsonl から取り込み済み draftKey に紐づくイベントを物理削除する。
+ *
+ * 流れ:
+ *   1. ファイル全体を読む (snapshot A)
+ *   2. snapshot A 中で削除対象を判定、残すべきイベントを集める
+ *   3. もう一度読む (snapshot B)。snapshot A 以降に追記された部分を抽出
+ *   4. 残すべきイベント + 追記部分を書き戻す
+ *
+ * これで読込〜書込の間に hooks が追記したイベントを失わない。
+ * snapshot B 取得後〜書込開始までの間の追記はロスする可能性があるが、
+ * ユーザー操作起点（取り込み完了時）でしか実行しないため実用上は許容範囲。
+ */
+export async function purgeImportedFromJsonl(
+  handle: FileSystemFileHandle,
+  importedDraftKeys: Set<string>,
+  opts: PurgeOptions = {}
+): Promise<PurgeResult> {
+  if (importedDraftKeys.size === 0) {
+    return { removedCount: 0, preservedCount: 0, appendedDuringPurge: 0 };
+  }
+
+  const ok = await ensureWritePermission(handle);
+  if (!ok) throw new Error('write permission denied');
+
+  // Snapshot A
+  const textA = await readHandleAsText(handle);
+  const eventsA = parseEventsJsonl(textA);
+  if (eventsA.length === 0) {
+    return { removedCount: 0, preservedCount: 0, appendedDuringPurge: 0 };
+  }
+
+  const { kept: filtered, removedCount } = filterOutImported(
+    eventsA,
+    importedDraftKeys,
+    opts.aggregateOpts ?? {}
+  );
+
+  // Snapshot B - キャプチャ間に追記された生テキスト部分を保全
+  const textB = await readHandleAsText(handle);
+  const newPortion = textB.length > textA.length ? textB.slice(textA.length) : '';
+  const appendedEvents = parseEventsJsonl(newPortion);
+
+  const merged = [...filtered, ...appendedEvents];
+  const out = merged.map((e) => JSON.stringify(e)).join('\n') + (merged.length > 0 ? '\n' : '');
+
+  await writeHandleText(handle, out);
+
+  return {
+    removedCount,
+    preservedCount: filtered.length,
+    appendedDuringPurge: appendedEvents.length,
+  };
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -3,10 +3,31 @@ import type { Task } from '@/types/task';
 import type { PomodoroSession } from '@/types/session';
 import type { AppSettings } from '@/types/settings';
 
+/** autolog インポートで取り込んだ下書きの追跡レコード（重複取り込み防止用） */
+export interface ImportedDraft {
+  draftKey: string;       // DraftTask.draftKey と同じ
+  taskId: string;         // 紐づく Task の id
+  importedAt: Date;       // 取り込み実施時刻
+  name: string;           // 取り込み時の name（後から探しやすいよう保存）
+  repo?: string;
+  branch?: string;
+  jstDate?: string;
+}
+
+/** autolog インポートのソース記憶（前回の events.jsonl を一発で開けるよう FileSystemFileHandle を保存） */
+export interface AutologSource {
+  id: 'default';                            // シングルトン
+  fileHandle?: FileSystemFileHandle;        // File System Access API 対応ブラウザのみ。IDB に構造化複製で保存可
+  fileName: string;                         // フォールバック表示用
+  lastReadAt: Date;
+}
+
 export class InsightLogDatabase extends Dexie {
   tasks!: Table<Task, string>;
   sessions!: Table<PomodoroSession, string>;
   settings!: Table<AppSettings, string>;
+  importedDrafts!: Table<ImportedDraft, string>;
+  autologSource!: Table<AutologSource, string>;
 
   constructor() {
     super('InsightLogDB');
@@ -66,6 +87,24 @@ export class InsightLogDatabase extends Dexie {
           await trans.table('tasks').put(rest);
         }
       }
+    });
+
+    // バージョン6: autolog インポート用 importedDrafts テーブル追加
+    // - 取り込み済みの draftKey を保存し、再インポート時の重複を防ぐ
+    this.version(6).stores({
+      tasks: 'id, name, createdAt, completedAt, *category, *aiToolsUsed',
+      sessions: 'id, startedAt, completedAt, type',
+      settings: 'id, memberId',
+      importedDrafts: 'draftKey, taskId, importedAt, jstDate, branch',
+    });
+
+    // バージョン7: autolog ファイル元の記憶（File System Access API の handle 保存）
+    this.version(7).stores({
+      tasks: 'id, name, createdAt, completedAt, *category, *aiToolsUsed',
+      sessions: 'id, startedAt, completedAt, type',
+      settings: 'id, memberId',
+      importedDrafts: 'draftKey, taskId, importedAt, jstDate, branch',
+      autologSource: 'id',
     });
   }
 }

--- a/src/lib/fsAccess.ts
+++ b/src/lib/fsAccess.ts
@@ -56,25 +56,34 @@ export async function getRememberedSource(): Promise<AutologSource | undefined> 
 }
 
 interface PermissionAwareHandle {
-  queryPermission?: (opts: { mode: 'read' }) => Promise<PermissionState>;
-  requestPermission?: (opts: { mode: 'read' }) => Promise<PermissionState>;
+  queryPermission?: (opts: { mode: 'read' | 'readwrite' }) => Promise<PermissionState>;
+  requestPermission?: (opts: { mode: 'read' | 'readwrite' }) => Promise<PermissionState>;
 }
 
-/** read 権限を確保する。granted なら true */
-export async function ensureReadPermission(
-  handle: FileSystemFileHandle
+/** 権限を確保する。granted なら true */
+async function ensurePermission(
+  handle: FileSystemFileHandle,
+  mode: 'read' | 'readwrite'
 ): Promise<boolean> {
   const h = handle as FileSystemFileHandle & PermissionAwareHandle;
   if (h.queryPermission) {
-    const cur = await h.queryPermission({ mode: 'read' });
+    const cur = await h.queryPermission({ mode });
     if (cur === 'granted') return true;
   }
   if (h.requestPermission) {
-    const next = await h.requestPermission({ mode: 'read' });
+    const next = await h.requestPermission({ mode });
     return next === 'granted';
   }
-  // 旧 API: getFile が走ればよしとする
+  // 旧 API: I/O が走ればよしとする
   return true;
+}
+
+export function ensureReadPermission(handle: FileSystemFileHandle): Promise<boolean> {
+  return ensurePermission(handle, 'read');
+}
+
+export function ensureWritePermission(handle: FileSystemFileHandle): Promise<boolean> {
+  return ensurePermission(handle, 'readwrite');
 }
 
 /** 記憶用に handle と filename を保存する */
@@ -94,4 +103,17 @@ export async function rememberSource(
 export async function readHandleAsText(handle: FileSystemFileHandle): Promise<string> {
   const file = await handle.getFile();
   return file.text();
+}
+
+/** handle に text を書き戻す（既存内容を完全置換） */
+export async function writeHandleText(
+  handle: FileSystemFileHandle,
+  text: string
+): Promise<void> {
+  const writable = await handle.createWritable();
+  try {
+    await writable.write(text);
+  } finally {
+    await writable.close();
+  }
 }

--- a/src/lib/fsAccess.ts
+++ b/src/lib/fsAccess.ts
@@ -1,0 +1,97 @@
+// File System Access API のラッパー
+// 対応: Chromium 系 (Chrome / Edge / Opera)。Firefox / Safari は非対応。
+// 非対応ブラウザでは型エラーを避けるため、`as any` ではなく feature detection で分岐する。
+
+import { db, type AutologSource } from './db';
+
+interface ShowOpenFilePickerOptions {
+  types?: { description?: string; accept?: Record<string, string[]> }[];
+  multiple?: boolean;
+  excludeAcceptAllOption?: boolean;
+}
+
+type ShowOpenFilePicker = (
+  opts?: ShowOpenFilePickerOptions
+) => Promise<FileSystemFileHandle[]>;
+
+type WindowWithFsApi = Window & { showOpenFilePicker?: ShowOpenFilePicker };
+
+/** File System Access API が利用可能か */
+export function isFsAccessSupported(): boolean {
+  return typeof window !== 'undefined' && 'showOpenFilePicker' in window;
+}
+
+/** ピッカーを開いて handle を返す。非対応ブラウザは null。 */
+export async function pickJsonlFile(): Promise<FileSystemFileHandle | null> {
+  const w = window as WindowWithFsApi;
+  if (!w.showOpenFilePicker) return null;
+  try {
+    const [handle] = await w.showOpenFilePicker({
+      types: [
+        {
+          description: 'JSON Lines',
+          accept: { 'application/x-ndjson': ['.jsonl', '.json', '.txt'] },
+        },
+      ],
+      multiple: false,
+    });
+    return handle;
+  } catch (err) {
+    // ユーザーがキャンセルしたら AbortError。それ以外は再送出。
+    if (err && typeof err === 'object' && 'name' in err && err.name === 'AbortError') {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/** 保存された handle を取得し、必要なら read 権限を再要求する */
+export async function getRememberedHandle(): Promise<FileSystemFileHandle | null> {
+  const src = await db.autologSource.get('default');
+  return src?.fileHandle ?? null;
+}
+
+export async function getRememberedSource(): Promise<AutologSource | undefined> {
+  return db.autologSource.get('default');
+}
+
+interface PermissionAwareHandle {
+  queryPermission?: (opts: { mode: 'read' }) => Promise<PermissionState>;
+  requestPermission?: (opts: { mode: 'read' }) => Promise<PermissionState>;
+}
+
+/** read 権限を確保する。granted なら true */
+export async function ensureReadPermission(
+  handle: FileSystemFileHandle
+): Promise<boolean> {
+  const h = handle as FileSystemFileHandle & PermissionAwareHandle;
+  if (h.queryPermission) {
+    const cur = await h.queryPermission({ mode: 'read' });
+    if (cur === 'granted') return true;
+  }
+  if (h.requestPermission) {
+    const next = await h.requestPermission({ mode: 'read' });
+    return next === 'granted';
+  }
+  // 旧 API: getFile が走ればよしとする
+  return true;
+}
+
+/** 記憶用に handle と filename を保存する */
+export async function rememberSource(
+  handle: FileSystemFileHandle | null,
+  fileName: string
+): Promise<void> {
+  await db.autologSource.put({
+    id: 'default',
+    fileHandle: handle ?? undefined,
+    fileName,
+    lastReadAt: new Date(),
+  });
+}
+
+/** handle から File を読む */
+export async function readHandleAsText(handle: FileSystemFileHandle): Promise<string> {
+  const file = await handle.getFile();
+  return file.text();
+}

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -4,10 +4,14 @@ import type {
   AutologEvent,
   SessionStartEvent,
   SessionProgressEvent,
+  SessionEndEvent,
   GitCommitEvent,
   DraftTask,
   AggregateOptions,
 } from '@/types/import';
+
+/** session_progress / session_end どちらも累積メトリクスを持つので統一して扱う */
+type SessionProgressLike = SessionProgressEvent | SessionEndEvent;
 
 /**
  * events.jsonl のテキスト全体をパースする。空行・パース失敗行はスキップ。
@@ -40,6 +44,7 @@ function isAutologEvent(obj: unknown): obj is AutologEvent {
   return [
     'session_start',
     'session_progress',
+    'session_end',
     'git_commit',
     'git_push',
     'git_checkout',
@@ -113,7 +118,7 @@ export function aggregateToDrafts(
     sessionIds: Set<string>;
     commits: GitCommitEvent[];
     starts: SessionStartEvent[];
-    progress: SessionProgressEvent[];
+    progress: SessionProgressLike[];
     firstTs: string;
     lastTs: string;
   };
@@ -155,6 +160,8 @@ export function aggregateToDrafts(
         b.starts.push(e);
         break;
       case 'session_progress':
+      case 'session_end':
+        // どちらも累積メトリクスを持つ。last-by-session で最新を採用する
         b.progress.push(e);
         break;
       // git_push / git_checkout は集計に直接寄与しない（境界候補のみ）
@@ -191,7 +198,7 @@ type RawBucket = {
   sessionIds: Set<string>;
   commits: GitCommitEvent[];
   starts: SessionStartEvent[];
-  progress: SessionProgressEvent[];
+  progress: SessionProgressLike[];
   firstTs: string;
   lastTs: string;
 };
@@ -205,7 +212,7 @@ function splitByGap(b: RawBucket, gapHours: number): RawBucket[] {
   type AnyEvent =
     | { kind: 'commit'; e: GitCommitEvent }
     | { kind: 'start'; e: SessionStartEvent }
-    | { kind: 'progress'; e: SessionProgressEvent };
+    | { kind: 'progress'; e: SessionProgressLike };
   const all: AnyEvent[] = [
     ...b.commits.map((e) => ({ kind: 'commit' as const, e })),
     ...b.starts.map((e) => ({ kind: 'start' as const, e })),
@@ -252,12 +259,12 @@ function buildDraft(b: {
   sessionIds: Set<string>;
   commits: GitCommitEvent[];
   starts: SessionStartEvent[];
-  progress: SessionProgressEvent[];
+  progress: SessionProgressLike[];
   firstTs: string;
   lastTs: string;
 }): DraftTask {
-  // duration: セッション単位の最新 session_progress を合算
-  const lastBySession = new Map<string, SessionProgressEvent>();
+  // duration / トークン: セッション単位の最新 session_progress / session_end を合算
+  const lastBySession = new Map<string, SessionProgressLike>();
   for (const p of b.progress) {
     const cur = lastBySession.get(p.session_id);
     if (!cur || p.ts > cur.ts) {
@@ -266,6 +273,11 @@ function buildDraft(b: {
   }
   let durationMs = 0;
   let costUsd = 0;
+  let turnCount = 0;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let cacheReadInputTokens = 0;
+  let cacheCreationInputTokens = 0;
   let hasDuration = false;
   for (const p of lastBySession.values()) {
     if (typeof p.duration_ms === 'number') {
@@ -273,6 +285,13 @@ function buildDraft(b: {
       hasDuration = true;
     }
     if (typeof p.cost_usd === 'number') costUsd += p.cost_usd;
+    if (typeof p.turn_count === 'number') turnCount += p.turn_count;
+    if (typeof p.input_tokens === 'number') inputTokens += p.input_tokens;
+    if (typeof p.output_tokens === 'number') outputTokens += p.output_tokens;
+    if (typeof p.cache_read_input_tokens === 'number')
+      cacheReadInputTokens += p.cache_read_input_tokens;
+    if (typeof p.cache_creation_input_tokens === 'number')
+      cacheCreationInputTokens += p.cache_creation_input_tokens;
   }
 
   // duration_ms が一切取れていない場合のフォールバック:
@@ -318,6 +337,9 @@ function buildDraft(b: {
   noteLines.push(`- 期間: ${b.firstTs} 〜 ${b.lastTs}`);
   noteLines.push(`- セッション数: ${b.sessionIds.size}`);
   noteLines.push(`- コミット数: ${sortedCommits.length}`);
+  if (turnCount > 0) noteLines.push(`- 累計ターン数: ${turnCount}`);
+  if (outputTokens > 0)
+    noteLines.push(`- 累計トークン: 入力 ${inputTokens} / 出力 ${outputTokens}`);
   if (costUsd > 0) noteLines.push(`- 累計 Claude コスト: $${costUsd.toFixed(3)}`);
 
   // category: commit subject 先頭の conventional commits っぽいプレフィックスで推測
@@ -351,6 +373,12 @@ function buildDraft(b: {
       firstTs: b.firstTs,
       lastTs: b.lastTs,
       costUsd: costUsd > 0 ? costUsd : undefined,
+      turnCount: turnCount > 0 ? turnCount : undefined,
+      inputTokens: inputTokens > 0 ? inputTokens : undefined,
+      outputTokens: outputTokens > 0 ? outputTokens : undefined,
+      cacheReadInputTokens: cacheReadInputTokens > 0 ? cacheReadInputTokens : undefined,
+      cacheCreationInputTokens:
+        cacheCreationInputTokens > 0 ? cacheCreationInputTokens : undefined,
     },
   };
 }

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -1,0 +1,264 @@
+// Claude Code hooks の autolog (events.jsonl) を InsightLog の下書きタスクへ変換する
+
+import type {
+  AutologEvent,
+  SessionStartEvent,
+  SessionProgressEvent,
+  GitCommitEvent,
+  DraftTask,
+  AggregateOptions,
+} from '@/types/import';
+
+/**
+ * events.jsonl のテキスト全体をパースする。空行・パース失敗行はスキップ。
+ * 返り値は型ガード済みのイベント配列。
+ */
+export function parseEventsJsonl(text: string): AutologEvent[] {
+  const out: AutologEvent[] = [];
+  const lines = text.split('\n');
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+    try {
+      const obj = JSON.parse(line);
+      if (isAutologEvent(obj)) {
+        out.push(obj);
+      }
+    } catch {
+      // 1行壊れていても続行
+    }
+  }
+  return out;
+}
+
+function isAutologEvent(obj: unknown): obj is AutologEvent {
+  if (!obj || typeof obj !== 'object') return false;
+  const o = obj as Record<string, unknown>;
+  if (typeof o.ts !== 'string') return false;
+  if (typeof o.type !== 'string') return false;
+  if (typeof o.session_id !== 'string') return false;
+  return [
+    'session_start',
+    'session_progress',
+    'git_commit',
+    'git_push',
+    'git_checkout',
+  ].includes(o.type);
+}
+
+/**
+ * 期間フィルタの判定。境界は両端を含む（since 00:00:00 〜 until 23:59:59.999）。
+ */
+function inRange(ts: string, since?: string, until?: string): boolean {
+  if (since && ts < `${since}T00:00:00.000Z`) return false;
+  if (until && ts > `${until}T23:59:59.999Z`) return false;
+  return true;
+}
+
+/**
+ * リポ名（toplevel パスの basename）。表示用。
+ */
+export function repoNameOf(repo: string | undefined): string | undefined {
+  if (!repo) return undefined;
+  const parts = repo.split('/').filter(Boolean);
+  return parts[parts.length - 1] ?? repo;
+}
+
+/**
+ * events から「repo × branch」単位で下書きタスクを生成する。
+ *
+ * グルーピング規則:
+ *   - 同じ (repo, branch) に属する全イベントを 1 タスクの候補とする
+ *   - repo か branch が無いイベントは "(unknown-repo)" / "(detached)" にフォールバック
+ *   - duration_ms はそのセッション群の最新 session_progress を採用（複数セッションがあれば合算）
+ *   - subject は時系列でユニーク化（同じメッセージの重複コミットは1回）
+ *
+ * 制約:
+ *   - 同じブランチで複数の論理タスクをこなした日は 1 つにまとまる（人間が分割編集する前提）
+ */
+export function aggregateToDrafts(
+  events: AutologEvent[],
+  opts: AggregateOptions = {}
+): DraftTask[] {
+  const filtered = events.filter((e) => {
+    if (!inRange(e.ts, opts.since, opts.until)) return false;
+    if (opts.repoFilter && opts.repoFilter.length > 0) {
+      if (!e.repo || !opts.repoFilter.includes(e.repo)) return false;
+    }
+    return true;
+  });
+
+  type Bucket = {
+    repo?: string;
+    branch?: string;
+    sessionIds: Set<string>;
+    commits: GitCommitEvent[];
+    starts: SessionStartEvent[];
+    progress: SessionProgressEvent[];
+    firstTs: string;
+    lastTs: string;
+  };
+
+  const buckets = new Map<string, Bucket>();
+  const keyOf = (repo?: string, branch?: string) =>
+    `${repo ?? '(unknown-repo)'}::${branch ?? '(detached)'}`;
+
+  for (const e of filtered) {
+    const k = keyOf(e.repo, e.branch);
+    let b = buckets.get(k);
+    if (!b) {
+      b = {
+        repo: e.repo,
+        branch: e.branch,
+        sessionIds: new Set(),
+        commits: [],
+        starts: [],
+        progress: [],
+        firstTs: e.ts,
+        lastTs: e.ts,
+      };
+      buckets.set(k, b);
+    }
+    b.sessionIds.add(e.session_id);
+    if (e.ts < b.firstTs) b.firstTs = e.ts;
+    if (e.ts > b.lastTs) b.lastTs = e.ts;
+    switch (e.type) {
+      case 'git_commit':
+        b.commits.push(e);
+        break;
+      case 'session_start':
+        b.starts.push(e);
+        break;
+      case 'session_progress':
+        b.progress.push(e);
+        break;
+      // git_push / git_checkout は集計に直接寄与しない（境界候補のみ）
+    }
+  }
+
+  // commit が 0 件のバケットは「セッションは開いたが何もコミットしてない」状態。
+  // タスク化する意味が薄いので除外。session のみ拾いたいユースケースが出たら緩める。
+  const drafts: DraftTask[] = [];
+  for (const b of buckets.values()) {
+    if (b.commits.length === 0) continue;
+    drafts.push(buildDraft(b));
+  }
+
+  // 開始時刻の昇順で並べる（古いものから順）
+  drafts.sort((a, b) => a.meta.firstTs.localeCompare(b.meta.firstTs));
+  return drafts;
+}
+
+function buildDraft(b: {
+  repo?: string;
+  branch?: string;
+  sessionIds: Set<string>;
+  commits: GitCommitEvent[];
+  starts: SessionStartEvent[];
+  progress: SessionProgressEvent[];
+  firstTs: string;
+  lastTs: string;
+}): DraftTask {
+  // duration: セッション単位の最新 session_progress を合算
+  const lastBySession = new Map<string, SessionProgressEvent>();
+  for (const p of b.progress) {
+    const cur = lastBySession.get(p.session_id);
+    if (!cur || p.ts > cur.ts) {
+      lastBySession.set(p.session_id, p);
+    }
+  }
+  let durationMs = 0;
+  let costUsd = 0;
+  for (const p of lastBySession.values()) {
+    if (typeof p.duration_ms === 'number') durationMs += p.duration_ms;
+    if (typeof p.cost_usd === 'number') costUsd += p.cost_usd;
+  }
+
+  // subject 群を時系列でユニーク化
+  const sortedCommits = [...b.commits].sort((x, y) => x.ts.localeCompare(y.ts));
+  const seen = new Set<string>();
+  const uniqSubjects: string[] = [];
+  for (const c of sortedCommits) {
+    const s = c.subject?.trim();
+    if (!s) continue;
+    if (seen.has(s)) continue;
+    seen.add(s);
+    uniqSubjects.push(s);
+  }
+
+  // name: 最初の subject。subject 全くない場合は branch / repo から
+  const repoName = repoNameOf(b.repo);
+  const name =
+    uniqSubjects[0] ??
+    (b.branch ? `${repoName ?? 'repo'} / ${b.branch}` : repoName ?? '(unknown task)');
+
+  // notes: 残りの subject + メタ情報を時系列で並べる
+  const noteLines: string[] = [];
+  if (uniqSubjects.length > 1) {
+    noteLines.push('## コミット一覧');
+    for (const s of uniqSubjects) noteLines.push(`- ${s}`);
+  }
+  noteLines.push('');
+  noteLines.push('## autolog メタ');
+  noteLines.push(`- repo: ${repoName ?? '(unknown)'}`);
+  if (b.branch) noteLines.push(`- branch: ${b.branch}`);
+  noteLines.push(`- 期間: ${b.firstTs} 〜 ${b.lastTs}`);
+  noteLines.push(`- セッション数: ${b.sessionIds.size}`);
+  noteLines.push(`- コミット数: ${sortedCommits.length}`);
+  if (costUsd > 0) noteLines.push(`- 累計 Claude コスト: $${costUsd.toFixed(3)}`);
+
+  // category: commit subject 先頭の conventional commits っぽいプレフィックスで推測
+  const categoryGuess = guessCategory(uniqSubjects);
+
+  // taskUrl: 推測しない（リポによって規約が違うため）
+
+  const durationMin = Math.max(1, Math.round(durationMs / 60000));
+
+  return {
+    draftKey: `${b.repo ?? 'unknown'}::${b.branch ?? 'detached'}::${b.firstTs}`,
+    name,
+    taskUrl: undefined,
+    duration: durationMin,
+    reworkCount: 0,
+    category: categoryGuess,
+    notes: noteLines.join('\n'),
+    meta: {
+      repo: b.repo,
+      repoName,
+      branch: b.branch,
+      sessionIds: [...b.sessionIds],
+      commitCount: sortedCommits.length,
+      firstTs: b.firstTs,
+      lastTs: b.lastTs,
+      costUsd: costUsd > 0 ? costUsd : undefined,
+    },
+  };
+}
+
+/**
+ * コミット subject 先頭のプレフィックスからカテゴリを推測。
+ * 推測できなければ空配列。
+ */
+function guessCategory(subjects: string[]): string[] {
+  const PREFIX_MAP: Record<string, string> = {
+    feat: '機能開発',
+    fix: 'バグ修正',
+    refactor: 'リファクタ',
+    test: 'テスト',
+    docs: 'ドキュメント',
+    chore: '雑務',
+    perf: 'パフォーマンス',
+    style: 'スタイル',
+    build: 'ビルド',
+    ci: 'CI',
+  };
+  const found = new Set<string>();
+  for (const s of subjects) {
+    const m = s.match(/^([a-z]+)(?:\([^)]*\))?:/i);
+    if (m) {
+      const cat = PREFIX_MAP[m[1].toLowerCase()];
+      if (cat) found.add(cat);
+    }
+  }
+  return [...found];
+}

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -387,6 +387,42 @@ function buildDraft(b: {
  * コミット subject 先頭のプレフィックスからカテゴリを推測。
  * 推測できなければ空配列。
  */
+/**
+ * 各イベントがどの DraftTask に属するかを判定して Map で返す。
+ * 属する draft が無いイベント（フィルタ外、commit 0 件バケット等）は含まれない。
+ *
+ * 取り込み済み draftKey のイベントを events.jsonl から物理削除する用途で使う。
+ */
+export function eventsByDraftKey(
+  events: AutologEvent[],
+  opts: AggregateOptions = {}
+): Map<AutologEvent, string> {
+  const drafts = aggregateToDrafts(events, opts);
+  const result = new Map<AutologEvent, string>();
+  for (const e of events) {
+    for (const d of drafts) {
+      if (eventMatchesDraft(e, d)) {
+        result.set(e, d.draftKey);
+        break;
+      }
+    }
+  }
+  return result;
+}
+
+function eventMatchesDraft(e: AutologEvent, d: DraftTask): boolean {
+  const repoKey = e.repo ?? '(unknown-repo)';
+  const draftRepoKey = d.meta.repo ?? '(unknown-repo)';
+  if (repoKey !== draftRepoKey) return false;
+  const branchKey = e.branch ?? '(detached)';
+  const draftBranchKey = d.meta.branch ?? '(detached)';
+  if (branchKey !== draftBranchKey) return false;
+  if (d.meta.jstDate && tsToJstDate(e.ts) !== d.meta.jstDate) return false;
+  if (e.ts < d.meta.firstTs) return false;
+  if (e.ts > d.meta.lastTs) return false;
+  return true;
+}
+
 function guessCategory(subjects: string[]): string[] {
   const PREFIX_MAP: Record<string, string> = {
     feat: '機能開発',

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -46,12 +46,27 @@ function isAutologEvent(obj: unknown): obj is AutologEvent {
   ].includes(o.type);
 }
 
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
 /**
- * 期間フィルタの判定。境界は両端を含む（since 00:00:00 〜 until 23:59:59.999）。
+ * ISO 8601 UTC 文字列 → JST(UTC+9) の YYYY-MM-DD。
+ * パース不能なら空文字。
+ */
+export function tsToJstDate(ts: string): string {
+  const t = Date.parse(ts);
+  if (Number.isNaN(t)) return '';
+  return new Date(t + JST_OFFSET_MS).toISOString().slice(0, 10);
+}
+
+/**
+ * 期間フィルタ。since/until は JST 解釈の YYYY-MM-DD（両端含む）。
  */
 function inRange(ts: string, since?: string, until?: string): boolean {
-  if (since && ts < `${since}T00:00:00.000Z`) return false;
-  if (until && ts > `${until}T23:59:59.999Z`) return false;
+  if (!since && !until) return true;
+  const date = tsToJstDate(ts);
+  if (!date) return false;
+  if (since && date < since) return false;
+  if (until && date > until) return false;
   return true;
 }
 
@@ -65,21 +80,24 @@ export function repoNameOf(repo: string | undefined): string | undefined {
 }
 
 /**
- * events から「repo × branch」単位で下書きタスクを生成する。
+ * events から下書きタスクを生成する。
  *
- * グルーピング規則:
- *   - 同じ (repo, branch) に属する全イベントを 1 タスクの候補とする
+ * グルーピング規則（デフォルト `groupBy: 'branch-day'`）:
+ *   - 同じ (repo, branch, JST 日付) に属する全イベントを 1 タスク候補とする
  *   - repo か branch が無いイベントは "(unknown-repo)" / "(detached)" にフォールバック
- *   - duration_ms はそのセッション群の最新 session_progress を採用（複数セッションがあれば合算）
+ *   - duration_ms はセッションごとの最終 session_progress を合算
  *   - subject は時系列でユニーク化（同じメッセージの重複コミットは1回）
+ *   - gapHours 指定時はバケット内を更にイベント間ギャップで分割
  *
- * 制約:
- *   - 同じブランチで複数の論理タスクをこなした日は 1 つにまとまる（人間が分割編集する前提）
+ * グルーピング規則（`groupBy: 'branch'`）:
+ *   - JST 日付を無視。複数日に跨いだ同一ブランチ作業を 1 つにまとめる
  */
 export function aggregateToDrafts(
   events: AutologEvent[],
   opts: AggregateOptions = {}
 ): DraftTask[] {
+  const groupBy = opts.groupBy ?? 'branch-day';
+
   const filtered = events.filter((e) => {
     if (!inRange(e.ts, opts.since, opts.until)) return false;
     if (opts.repoFilter && opts.repoFilter.length > 0) {
@@ -91,6 +109,7 @@ export function aggregateToDrafts(
   type Bucket = {
     repo?: string;
     branch?: string;
+    jstDate?: string;
     sessionIds: Set<string>;
     commits: GitCommitEvent[];
     starts: SessionStartEvent[];
@@ -99,17 +118,23 @@ export function aggregateToDrafts(
     lastTs: string;
   };
 
+  const bucketKey = (e: AutologEvent): string => {
+    const repoKey = e.repo ?? '(unknown-repo)';
+    const branchKey = e.branch ?? '(detached)';
+    if (groupBy === 'branch') return `${repoKey}::${branchKey}`;
+    return `${repoKey}::${branchKey}::${tsToJstDate(e.ts)}`;
+  };
+
   const buckets = new Map<string, Bucket>();
-  const keyOf = (repo?: string, branch?: string) =>
-    `${repo ?? '(unknown-repo)'}::${branch ?? '(detached)'}`;
 
   for (const e of filtered) {
-    const k = keyOf(e.repo, e.branch);
+    const k = bucketKey(e);
     let b = buckets.get(k);
     if (!b) {
       b = {
         repo: e.repo,
         branch: e.branch,
+        jstDate: groupBy === 'branch-day' ? tsToJstDate(e.ts) : undefined,
         sessionIds: new Set(),
         commits: [],
         starts: [],
@@ -136,10 +161,20 @@ export function aggregateToDrafts(
     }
   }
 
+  // gapHours 指定時はバケット内をギャップで分割
+  const effectiveBuckets: Bucket[] = [];
+  for (const b of buckets.values()) {
+    if (opts.gapHours && opts.gapHours > 0) {
+      effectiveBuckets.push(...splitByGap(b, opts.gapHours));
+    } else {
+      effectiveBuckets.push(b);
+    }
+  }
+
   // commit が 0 件のバケットは「セッションは開いたが何もコミットしてない」状態。
   // タスク化する意味が薄いので除外。session のみ拾いたいユースケースが出たら緩める。
   const drafts: DraftTask[] = [];
-  for (const b of buckets.values()) {
+  for (const b of effectiveBuckets) {
     if (b.commits.length === 0) continue;
     drafts.push(buildDraft(b));
   }
@@ -149,9 +184,71 @@ export function aggregateToDrafts(
   return drafts;
 }
 
+type RawBucket = {
+  repo?: string;
+  branch?: string;
+  jstDate?: string;
+  sessionIds: Set<string>;
+  commits: GitCommitEvent[];
+  starts: SessionStartEvent[];
+  progress: SessionProgressEvent[];
+  firstTs: string;
+  lastTs: string;
+};
+
+/**
+ * バケット内のイベントを時系列で並べ、gapHours を超える隙間で分割する。
+ */
+function splitByGap(b: RawBucket, gapHours: number): RawBucket[] {
+  const gapMs = gapHours * 60 * 60 * 1000;
+  // 全イベントを時系列ソート
+  type AnyEvent =
+    | { kind: 'commit'; e: GitCommitEvent }
+    | { kind: 'start'; e: SessionStartEvent }
+    | { kind: 'progress'; e: SessionProgressEvent };
+  const all: AnyEvent[] = [
+    ...b.commits.map((e) => ({ kind: 'commit' as const, e })),
+    ...b.starts.map((e) => ({ kind: 'start' as const, e })),
+    ...b.progress.map((e) => ({ kind: 'progress' as const, e })),
+  ];
+  all.sort((x, y) => x.e.ts.localeCompare(y.e.ts));
+
+  if (all.length === 0) return [b];
+
+  const segments: RawBucket[] = [];
+  let cur: RawBucket | null = null;
+  let prevMs = 0;
+  for (const x of all) {
+    const ms = Date.parse(x.e.ts);
+    if (!cur || ms - prevMs > gapMs) {
+      cur = {
+        repo: b.repo,
+        branch: b.branch,
+        jstDate: b.jstDate,
+        sessionIds: new Set(),
+        commits: [],
+        starts: [],
+        progress: [],
+        firstTs: x.e.ts,
+        lastTs: x.e.ts,
+      };
+      segments.push(cur);
+    }
+    cur.sessionIds.add(x.e.session_id);
+    if (x.e.ts < cur.firstTs) cur.firstTs = x.e.ts;
+    if (x.e.ts > cur.lastTs) cur.lastTs = x.e.ts;
+    if (x.kind === 'commit') cur.commits.push(x.e);
+    else if (x.kind === 'start') cur.starts.push(x.e);
+    else cur.progress.push(x.e);
+    prevMs = ms;
+  }
+  return segments;
+}
+
 function buildDraft(b: {
   repo?: string;
   branch?: string;
+  jstDate?: string;
   sessionIds: Set<string>;
   commits: GitCommitEvent[];
   starts: SessionStartEvent[];
@@ -202,6 +299,7 @@ function buildDraft(b: {
   noteLines.push('## autolog メタ');
   noteLines.push(`- repo: ${repoName ?? '(unknown)'}`);
   if (b.branch) noteLines.push(`- branch: ${b.branch}`);
+  if (b.jstDate) noteLines.push(`- 日付 (JST): ${b.jstDate}`);
   noteLines.push(`- 期間: ${b.firstTs} 〜 ${b.lastTs}`);
   noteLines.push(`- セッション数: ${b.sessionIds.size}`);
   noteLines.push(`- コミット数: ${sortedCommits.length}`);
@@ -214,8 +312,14 @@ function buildDraft(b: {
 
   const durationMin = Math.max(1, Math.round(durationMs / 60000));
 
+  // draftKey: 取り込み済み判定に使うので決定論的に作る。
+  // - jstDate があればそれを含める（同じブランチでも別日なら別キー）
+  // - gap split 由来の分割では firstTs が違うので含める
+  const datePart = b.jstDate ?? 'no-date';
+  const draftKey = `${b.repo ?? 'unknown'}::${b.branch ?? 'detached'}::${datePart}::${b.firstTs}`;
+
   return {
-    draftKey: `${b.repo ?? 'unknown'}::${b.branch ?? 'detached'}::${b.firstTs}`,
+    draftKey,
     name,
     taskUrl: undefined,
     duration: durationMin,
@@ -226,6 +330,7 @@ function buildDraft(b: {
       repo: b.repo,
       repoName,
       branch: b.branch,
+      jstDate: b.jstDate,
       sessionIds: [...b.sessionIds],
       commitCount: sortedCommits.length,
       firstTs: b.firstTs,

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -266,9 +266,24 @@ function buildDraft(b: {
   }
   let durationMs = 0;
   let costUsd = 0;
+  let hasDuration = false;
   for (const p of lastBySession.values()) {
-    if (typeof p.duration_ms === 'number') durationMs += p.duration_ms;
+    if (typeof p.duration_ms === 'number') {
+      durationMs += p.duration_ms;
+      hasDuration = true;
+    }
     if (typeof p.cost_usd === 'number') costUsd += p.cost_usd;
+  }
+
+  // duration_ms が一切取れていない場合のフォールバック:
+  // バケット内の最初と最後のイベントの ts 差分を上限値として採用する
+  // （Stop hook の入力に duration が含まれないバージョン / 旧データ向け）
+  if (!hasDuration) {
+    const first = Date.parse(b.firstTs);
+    const last = Date.parse(b.lastTs);
+    if (!Number.isNaN(first) && !Number.isNaN(last) && last > first) {
+      durationMs = last - first;
+    }
   }
 
   // subject 群を時系列でユニーク化

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -16,11 +16,13 @@ import { formatMinutes } from '@/lib/time';
 // モーダルを遅延ロード
 const StatsModal = lazy(() => import('@/components/statistics/StatsModal').then(m => ({ default: m.StatsModal })));
 const SettingsModal = lazy(() => import('@/components/settings/SettingsModal').then(m => ({ default: m.SettingsModal })));
+const ImportModal = lazy(() => import('@/components/import/ImportModal').then(m => ({ default: m.ImportModal })));
 
 export function HomePage() {
   const [showTaskList, setShowTaskList] = useState(false);
   const [showStats, setShowStats] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
+  const [showImport, setShowImport] = useState(false);
   const { currentCycle, mode } = useTimer();
   const stats = useStatistics('today');
   const { settings } = useSettings();
@@ -32,7 +34,7 @@ export function HomePage() {
         onTaskListClick={() => setShowTaskList(true)}
         onStatsClick={() => setShowStats(true)}
         onSettingsClick={() => setShowSettings(true)}
-
+        onImportClick={() => setShowImport(true)}
       />
 
       {showTimer && (
@@ -84,7 +86,10 @@ export function HomePage() {
         {showSettings && <SettingsModal isOpen={showSettings} onClose={() => setShowSettings(false)} />}
       </Suspense>
 
-
+      {/* インポートモーダル（遅延ロード） */}
+      <Suspense fallback={null}>
+        {showImport && <ImportModal isOpen={showImport} onClose={() => setShowImport(false)} />}
+      </Suspense>
     </Container>
   );
 }

--- a/src/tests/unit/autologMaintenance.test.ts
+++ b/src/tests/unit/autologMaintenance.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { parseEventsJsonl, aggregateToDrafts } from '@/lib/import';
+import { filterOutImported } from '@/lib/autologMaintenance';
+
+const sample = [
+  // Day 1 InsightLog feat/x (s1)
+  '{"ts":"2026-05-18T10:00:00.000Z","type":"session_start","session_id":"s1","repo":"/work/insightlog","branch":"feat/x"}',
+  '{"ts":"2026-05-18T10:05:00.000Z","type":"git_commit","session_id":"s1","repo":"/work/insightlog","branch":"feat/x","commit":"a1","subject":"feat: a1"}',
+  '{"ts":"2026-05-18T10:30:00.000Z","type":"session_progress","session_id":"s1","repo":"/work/insightlog","branch":"feat/x","duration_ms":1800000}',
+  // Day 1 other-repo feat/y (s2)
+  '{"ts":"2026-05-18T11:00:00.000Z","type":"session_start","session_id":"s2","repo":"/work/other","branch":"feat/y"}',
+  '{"ts":"2026-05-18T11:05:00.000Z","type":"git_commit","session_id":"s2","repo":"/work/other","branch":"feat/y","commit":"b1","subject":"docs: x"}',
+  '{"ts":"2026-05-18T11:30:00.000Z","type":"session_progress","session_id":"s2","repo":"/work/other","branch":"feat/y","duration_ms":1800000}',
+  // Day 2 InsightLog feat/x (s3)
+  '{"ts":"2026-05-19T09:00:00.000Z","type":"session_start","session_id":"s3","repo":"/work/insightlog","branch":"feat/x"}',
+  '{"ts":"2026-05-19T09:30:00.000Z","type":"git_commit","session_id":"s3","repo":"/work/insightlog","branch":"feat/x","commit":"a2","subject":"refactor: a2"}',
+  '{"ts":"2026-05-19T10:00:00.000Z","type":"session_progress","session_id":"s3","repo":"/work/insightlog","branch":"feat/x","duration_ms":3600000}',
+].join('\n');
+
+describe('filterOutImported', () => {
+  it('importedDraftKeys が空なら全件残る', () => {
+    const events = parseEventsJsonl(sample);
+    const result = filterOutImported(events, new Set());
+    expect(result.kept).toEqual(events);
+    expect(result.removedCount).toBe(0);
+  });
+
+  it('Day1 InsightLog の draft を取り込み済みにすると、その関連イベントだけが消える', () => {
+    const events = parseEventsJsonl(sample);
+    const drafts = aggregateToDrafts(events);
+    const day1Insightlog = drafts.find(
+      (d) => d.meta.repoName === 'insightlog' && d.meta.jstDate === '2026-05-18'
+    )!;
+    const result = filterOutImported(events, new Set([day1Insightlog.draftKey]));
+
+    // s1 系の 3 イベントが消える
+    expect(result.removedCount).toBe(3);
+    expect(result.kept).toHaveLength(events.length - 3);
+
+    // 残ったイベントに s1 のイベントが含まれない
+    expect(result.kept.every((e) => e.session_id !== 's1')).toBe(true);
+    // s2, s3 は残る
+    expect(result.kept.some((e) => e.session_id === 's2')).toBe(true);
+    expect(result.kept.some((e) => e.session_id === 's3')).toBe(true);
+  });
+
+  it('2 つの draft を同時指定するとそれぞれの関連イベントが全部消える', () => {
+    const events = parseEventsJsonl(sample);
+    const drafts = aggregateToDrafts(events);
+    const day1Insightlog = drafts.find(
+      (d) => d.meta.repoName === 'insightlog' && d.meta.jstDate === '2026-05-18'
+    )!;
+    const day2Insightlog = drafts.find(
+      (d) => d.meta.repoName === 'insightlog' && d.meta.jstDate === '2026-05-19'
+    )!;
+    const result = filterOutImported(
+      events,
+      new Set([day1Insightlog.draftKey, day2Insightlog.draftKey])
+    );
+
+    // s1 + s3 系で 6 件
+    expect(result.removedCount).toBe(6);
+    // 残るのは s2 系 3 件のみ
+    expect(result.kept).toHaveLength(3);
+    expect(result.kept.every((e) => e.session_id === 's2')).toBe(true);
+  });
+
+  it('存在しない draftKey を指定しても残るイベントは変わらない', () => {
+    const events = parseEventsJsonl(sample);
+    const result = filterOutImported(events, new Set(['nonexistent-key']));
+    expect(result.kept).toEqual(events);
+    expect(result.removedCount).toBe(0);
+  });
+
+  it('aggregateOpts を渡せば取り込み時と同じグルーピングで判定される', () => {
+    const events = parseEventsJsonl(sample);
+    // groupBy: 'branch' で InsightLog 全体が 1 つの draft
+    const draftsByBranch = aggregateToDrafts(events, { groupBy: 'branch' });
+    const insightlog = draftsByBranch.find((d) => d.meta.repoName === 'insightlog')!;
+    const result = filterOutImported(
+      events,
+      new Set([insightlog.draftKey]),
+      { groupBy: 'branch' }
+    );
+    // s1 + s3 系で 6 件
+    expect(result.removedCount).toBe(6);
+  });
+});

--- a/src/tests/unit/import.test.ts
+++ b/src/tests/unit/import.test.ts
@@ -1,14 +1,17 @@
 import { describe, it, expect } from 'vitest';
-import { parseEventsJsonl, aggregateToDrafts, repoNameOf } from '@/lib/import';
+import { parseEventsJsonl, aggregateToDrafts, repoNameOf, tsToJstDate } from '@/lib/import';
 
+// テストデータ: 全 ts は ISO 8601 UTC。JST 換算で確認しやすい時刻を選んでいる。
+// 注意: 2026-05-18T10:00Z = 2026-05-18 19:00 JST → JST 日付 2026-05-18
+//       2026-05-19T09:00Z = 2026-05-19 18:00 JST → JST 日付 2026-05-19
 const sampleJsonl = [
-  // Day 1 - InsightLog feat/x: 2 commits, 1 session, 30min, $0.5
+  // Day 1 (JST) - InsightLog feat/x: 2 sessions worth of commits
   '{"ts":"2026-05-18T10:00:00.000Z","type":"session_start","session_id":"s1","cwd":"/work/insightlog","repo":"/work/insightlog","repo_remote":"https://github.com/arkatom/InsightLog.git","branch":"feat/x"}',
   '{"ts":"2026-05-18T10:05:00.000Z","type":"git_commit","session_id":"s1","repo":"/work/insightlog","branch":"feat/x","commit":"a1","subject":"feat: add foo","files":3}',
   '{"ts":"2026-05-18T10:15:00.000Z","type":"git_commit","session_id":"s1","repo":"/work/insightlog","branch":"feat/x","commit":"a2","subject":"feat: add foo","files":1}',
   '{"ts":"2026-05-18T10:20:00.000Z","type":"git_commit","session_id":"s1","repo":"/work/insightlog","branch":"feat/x","commit":"a3","subject":"fix: typo","files":1}',
   '{"ts":"2026-05-18T10:30:00.000Z","type":"session_progress","session_id":"s1","repo":"/work/insightlog","branch":"feat/x","duration_ms":1800000,"cost_usd":0.5}',
-  // Day 1 - other-repo feat/y: 1 commit, 1 session, 15min
+  // Day 1 (JST) - other-repo feat/y
   '{"ts":"2026-05-18T11:00:00.000Z","type":"session_start","session_id":"s2","cwd":"/work/other","repo":"/work/other","branch":"feat/y"}',
   '{"ts":"2026-05-18T11:08:00.000Z","type":"git_commit","session_id":"s2","repo":"/work/other","branch":"feat/y","commit":"b1","subject":"docs: README update","files":2}',
   '{"ts":"2026-05-18T11:15:00.000Z","type":"session_progress","session_id":"s2","repo":"/work/other","branch":"feat/y","duration_ms":900000,"cost_usd":0.2}',
@@ -17,7 +20,7 @@ const sampleJsonl = [
   '',
   // 不明 type (should be skipped)
   '{"ts":"2026-05-18T12:00:00.000Z","type":"unknown_thing","session_id":"sX"}',
-  // Day 2 - InsightLog feat/x: 1 commit (continuing the same branch)
+  // Day 2 (JST) - InsightLog feat/x: 翌日に同じブランチを継続
   '{"ts":"2026-05-19T09:00:00.000Z","type":"session_start","session_id":"s3","repo":"/work/insightlog","branch":"feat/x"}',
   '{"ts":"2026-05-19T09:30:00.000Z","type":"git_commit","session_id":"s3","repo":"/work/insightlog","branch":"feat/x","commit":"a4","subject":"refactor: extract helper","files":2}',
   '{"ts":"2026-05-19T09:45:00.000Z","type":"session_progress","session_id":"s3","repo":"/work/insightlog","branch":"feat/x","duration_ms":2700000,"cost_usd":0.3}',
@@ -29,7 +32,7 @@ const sampleJsonl = [
 describe('parseEventsJsonl', () => {
   it('正常な行のみを取り込み、壊れた行と未知の type を捨てる', () => {
     const events = parseEventsJsonl(sampleJsonl);
-    // 期待: session_start * 4 + git_commit * 5 + session_progress * 4 = 13
+    // session_start * 4 + git_commit * 5 + session_progress * 4 = 13
     expect(events).toHaveLength(13);
     expect(events.every((e) => 'ts' in e && 'type' in e && 'session_id' in e)).toBe(true);
   });
@@ -54,66 +57,98 @@ describe('repoNameOf', () => {
   });
 });
 
-describe('aggregateToDrafts', () => {
-  it('repo × branch で 2 つの下書きを生成する（commit のないバケットは除外）', () => {
+describe('tsToJstDate', () => {
+  it('UTC を JST 日付 (UTC+9) に変換する', () => {
+    expect(tsToJstDate('2026-05-18T10:00:00.000Z')).toBe('2026-05-18'); // 19:00 JST
+    expect(tsToJstDate('2026-05-18T14:59:59.999Z')).toBe('2026-05-18'); // 23:59:59 JST 当日
+    expect(tsToJstDate('2026-05-18T15:00:00.000Z')).toBe('2026-05-19'); // 00:00 JST 翌日
+    expect(tsToJstDate('2026-05-18T00:00:00.000Z')).toBe('2026-05-18'); // 09:00 JST 当日
+  });
+
+  it('UTC 当日早朝 (JST 同日明け方) は JST も同日', () => {
+    expect(tsToJstDate('2026-05-18T00:01:00.000Z')).toBe('2026-05-18'); // 09:01 JST
+  });
+
+  it('パース不能なら空文字', () => {
+    expect(tsToJstDate('not-a-date')).toBe('');
+  });
+});
+
+describe('aggregateToDrafts — デフォルト (groupBy: branch-day, JST)', () => {
+  it('JST 日付ごとに分割される: 同じ feat/x が Day1 と Day2 で別下書きになる', () => {
     const events = parseEventsJsonl(sampleJsonl);
     const drafts = aggregateToDrafts(events);
-    expect(drafts).toHaveLength(2);
+    // Day1: insightlog/feat/x, Day1: other/feat/y, Day2: insightlog/feat/x = 3 件
+    expect(drafts).toHaveLength(3);
 
-    const insightlog = drafts.find((d) => d.meta.repoName === 'insightlog');
-    const other = drafts.find((d) => d.meta.repoName === 'other');
-    expect(insightlog).toBeDefined();
-    expect(other).toBeDefined();
+    const day1Insightlog = drafts.find(
+      (d) => d.meta.repoName === 'insightlog' && d.meta.jstDate === '2026-05-18'
+    );
+    const day1Other = drafts.find((d) => d.meta.repoName === 'other');
+    const day2Insightlog = drafts.find(
+      (d) => d.meta.repoName === 'insightlog' && d.meta.jstDate === '2026-05-19'
+    );
+    expect(day1Insightlog).toBeDefined();
+    expect(day1Other).toBeDefined();
+    expect(day2Insightlog).toBeDefined();
+  });
+
+  it('Day1 insightlog: s1 のみで duration 30 分', () => {
+    const drafts = aggregateToDrafts(parseEventsJsonl(sampleJsonl));
+    const d = drafts.find(
+      (x) => x.meta.repoName === 'insightlog' && x.meta.jstDate === '2026-05-18'
+    )!;
+    expect(d.duration).toBe(30);
+    expect(d.meta.sessionIds).toEqual(['s1']);
+    expect(d.meta.commitCount).toBe(3); // a1, a2, a3
+  });
+
+  it('Day2 insightlog: s3 のみで duration 45 分・1 コミット', () => {
+    const drafts = aggregateToDrafts(parseEventsJsonl(sampleJsonl));
+    const d = drafts.find(
+      (x) => x.meta.repoName === 'insightlog' && x.meta.jstDate === '2026-05-19'
+    )!;
+    expect(d.duration).toBe(45);
+    expect(d.meta.sessionIds).toEqual(['s3']);
+    expect(d.meta.commitCount).toBe(1);
+    expect(d.name).toBe('refactor: extract helper');
+  });
+
+  it('Day1 insightlog: subject dedupe (a1, a2 は同じ subject)', () => {
+    const drafts = aggregateToDrafts(parseEventsJsonl(sampleJsonl));
+    const d = drafts.find(
+      (x) => x.meta.repoName === 'insightlog' && x.meta.jstDate === '2026-05-18'
+    )!;
+    expect(d.notes).toContain('- feat: add foo');
+    expect(d.notes).toContain('- fix: typo');
+    expect(d.notes).not.toContain('- refactor: extract helper'); // それは Day2
   });
 
   it('日付昇順で並ぶ', () => {
     const drafts = aggregateToDrafts(parseEventsJsonl(sampleJsonl));
     expect(drafts[0].meta.firstTs <= drafts[1].meta.firstTs).toBe(true);
+    expect(drafts[1].meta.firstTs <= drafts[2].meta.firstTs).toBe(true);
   });
 
-  it('セッション最終 session_progress の duration を合算する（重複コミット subject は dedupe）', () => {
+  it('カテゴリ推測は各バケット内のみで判定', () => {
     const drafts = aggregateToDrafts(parseEventsJsonl(sampleJsonl));
-    const insightlog = drafts.find((d) => d.meta.repoName === 'insightlog')!;
-    // s1: 1800000ms (30min) + s3: 2700000ms (45min) = 4500000ms (75min)
-    expect(insightlog.duration).toBe(75);
-    // commit a1 と a2 は同じ subject "feat: add foo" → 1回だけ。a3=fix, a4=refactor とで合計 3 unique
-    expect(insightlog.notes).toContain('- feat: add foo');
-    expect(insightlog.notes).toContain('- fix: typo');
-    expect(insightlog.notes).toContain('- refactor: extract helper');
-    // 合計 4 commits（dedupe 前）
-    expect(insightlog.meta.commitCount).toBe(4);
+    const day1 = drafts.find(
+      (x) => x.meta.repoName === 'insightlog' && x.meta.jstDate === '2026-05-18'
+    )!;
+    const day2 = drafts.find(
+      (x) => x.meta.repoName === 'insightlog' && x.meta.jstDate === '2026-05-19'
+    )!;
+    expect(day1.category).toEqual(expect.arrayContaining(['機能開発', 'バグ修正']));
+    expect(day1.category).not.toContain('リファクタ');
+    expect(day2.category).toEqual(['リファクタ']);
   });
 
-  it('name はユニーク化された最初の subject', () => {
-    const drafts = aggregateToDrafts(parseEventsJsonl(sampleJsonl));
-    const insightlog = drafts.find((d) => d.meta.repoName === 'insightlog')!;
-    expect(insightlog.name).toBe('feat: add foo');
-  });
-
-  it('conventional commits プレフィックスからカテゴリを推測', () => {
-    const drafts = aggregateToDrafts(parseEventsJsonl(sampleJsonl));
-    const insightlog = drafts.find((d) => d.meta.repoName === 'insightlog')!;
-    // feat: + fix: + refactor: が含まれる
-    expect(insightlog.category).toEqual(
-      expect.arrayContaining(['機能開発', 'バグ修正', 'リファクタ'])
-    );
-  });
-
-  it('cost_usd を合算してメタに含める', () => {
-    const drafts = aggregateToDrafts(parseEventsJsonl(sampleJsonl));
-    const insightlog = drafts.find((d) => d.meta.repoName === 'insightlog')!;
-    // s1: 0.5 + s3: 0.3 = 0.8
-    expect(insightlog.meta.costUsd).toBeCloseTo(0.8, 5);
-  });
-
-  it('期間フィルタ since/until で範囲を絞れる', () => {
+  it('期間フィルタ since/until は JST 解釈', () => {
     const events = parseEventsJsonl(sampleJsonl);
     const dayOne = aggregateToDrafts(events, { since: '2026-05-18', until: '2026-05-18' });
-    // Day 1 だけだと insightlog/feat/x にも other-repo/feat/y にも commit がある
+    // JST 2026-05-18 のイベントだけ → insightlog/feat/x + other/feat/y = 2 件
     expect(dayOne).toHaveLength(2);
-    const insightlog = dayOne.find((d) => d.meta.repoName === 'insightlog')!;
-    // s3 を含まないので duration は s1 のみ = 30分
-    expect(insightlog.duration).toBe(30);
+    expect(dayOne.every((d) => d.meta.jstDate === '2026-05-18')).toBe(true);
   });
 
   it('repoFilter で repo を絞れる', () => {
@@ -132,10 +167,69 @@ describe('aggregateToDrafts', () => {
     expect(aggregateToDrafts([])).toEqual([]);
   });
 
-  it('セッション数とコミット数のメタが正しい', () => {
-    const drafts = aggregateToDrafts(parseEventsJsonl(sampleJsonl));
+  it('draftKey は repo + branch + jstDate + firstTs で決定論的', () => {
+    const events = parseEventsJsonl(sampleJsonl);
+    const a = aggregateToDrafts(events);
+    const b = aggregateToDrafts(events);
+    // 同じ入力なら draftKey も同じ（取り込み済み判定に使えるための前提）
+    expect(a.map((d) => d.draftKey)).toEqual(b.map((d) => d.draftKey));
+    // 各 draftKey は jstDate を含む
+    expect(a.every((d) => d.draftKey.includes(d.meta.jstDate ?? ''))).toBe(true);
+  });
+});
+
+describe('aggregateToDrafts — groupBy: branch (日付を無視)', () => {
+  it('複数日に跨ぐ同一ブランチ作業を 1 つにまとめる', () => {
+    const events = parseEventsJsonl(sampleJsonl);
+    const drafts = aggregateToDrafts(events, { groupBy: 'branch' });
+    // insightlog/feat/x + other/feat/y = 2 件 (chore/nothing は除外)
+    expect(drafts).toHaveLength(2);
+
     const insightlog = drafts.find((d) => d.meta.repoName === 'insightlog')!;
+    // 30min + 45min = 75min が合算
+    expect(insightlog.duration).toBe(75);
     expect(insightlog.meta.sessionIds.sort()).toEqual(['s1', 's3']);
     expect(insightlog.meta.commitCount).toBe(4);
+    expect(insightlog.meta.jstDate).toBeUndefined();
+  });
+
+  it('cost_usd を合算してメタに含める', () => {
+    const drafts = aggregateToDrafts(parseEventsJsonl(sampleJsonl), { groupBy: 'branch' });
+    const insightlog = drafts.find((d) => d.meta.repoName === 'insightlog')!;
+    // s1: 0.5 + s3: 0.3 = 0.8
+    expect(insightlog.meta.costUsd).toBeCloseTo(0.8, 5);
+  });
+});
+
+describe('aggregateToDrafts — gapHours オプション', () => {
+  it('gap = 0.5h なら Day1 insightlog 内の 10:30→ なし、Day2 09:00→9:45 は同一バケット内', () => {
+    // gapHours 適用は同一バケット内（branch-day）でも更に分割される
+    // Day1 s1 のイベントは 10:00 から 10:30 まで連続（gap < 30min）→ 1 タスク
+    // Day1 と Day2 はそもそも別 jstDate なので別バケット
+    const drafts = aggregateToDrafts(parseEventsJsonl(sampleJsonl), { gapHours: 0.5 });
+    expect(drafts.find((d) => d.meta.repoName === 'insightlog' && d.meta.jstDate === '2026-05-18'))
+      .toBeDefined();
+  });
+
+  it('branch グルーピングと gapHours 併用で日跨ぎ作業も時間で分割', () => {
+    const drafts = aggregateToDrafts(parseEventsJsonl(sampleJsonl), {
+      groupBy: 'branch',
+      gapHours: 6,
+    });
+    // insightlog/feat/x: s1 (Day1 10:00-10:30) ⟶ 23h ⟶ s3 (Day2 09:00-09:45)
+    // gap=6h → 分割される
+    const splits = drafts.filter((d) => d.meta.repoName === 'insightlog');
+    expect(splits).toHaveLength(2);
+    expect(splits[0].duration).toBe(30);
+    expect(splits[1].duration).toBe(45);
+  });
+
+  it('gapHours が十分大きければ分割しない', () => {
+    const drafts = aggregateToDrafts(parseEventsJsonl(sampleJsonl), {
+      groupBy: 'branch',
+      gapHours: 100,
+    });
+    const insightlog = drafts.find((d) => d.meta.repoName === 'insightlog')!;
+    expect(insightlog.duration).toBe(75); // 合算されたまま
   });
 });

--- a/src/tests/unit/import.test.ts
+++ b/src/tests/unit/import.test.ts
@@ -201,6 +201,53 @@ describe('aggregateToDrafts — groupBy: branch (日付を無視)', () => {
   });
 });
 
+describe('aggregateToDrafts — session_end イベントとトークン累計', () => {
+  it('session_end も session_progress と同じく累積メトリクスとして扱う', () => {
+    const lines = [
+      '{"ts":"2026-05-18T10:00:00.000Z","type":"git_commit","session_id":"sE","repo":"/work/x","branch":"main","commit":"c1","subject":"feat"}',
+      '{"ts":"2026-05-18T10:30:00.000Z","type":"session_progress","session_id":"sE","repo":"/work/x","branch":"main","duration_ms":1500000,"turn_count":5,"output_tokens":1000}',
+      // 後から session_end が来れば、より新しい値が採用される
+      '{"ts":"2026-05-18T11:00:00.000Z","type":"session_end","session_id":"sE","repo":"/work/x","branch":"main","end_reason":"clear","duration_ms":3600000,"turn_count":10,"input_tokens":50,"output_tokens":2000,"cache_read_input_tokens":100000,"cache_creation_input_tokens":5000}',
+    ].join('\n');
+    const drafts = aggregateToDrafts(parseEventsJsonl(lines));
+    expect(drafts).toHaveLength(1);
+    const d = drafts[0];
+    // session_end は session_progress より新しいので最新値が採用される: 3600000ms = 60分
+    expect(d.duration).toBe(60);
+    expect(d.meta.turnCount).toBe(10);
+    expect(d.meta.inputTokens).toBe(50);
+    expect(d.meta.outputTokens).toBe(2000);
+    expect(d.meta.cacheReadInputTokens).toBe(100000);
+    expect(d.meta.cacheCreationInputTokens).toBe(5000);
+  });
+
+  it('複数セッションのトークンは合算される', () => {
+    const lines = [
+      '{"ts":"2026-05-18T10:00:00.000Z","type":"git_commit","session_id":"sA","repo":"/work/x","branch":"main","commit":"c1","subject":"a"}',
+      '{"ts":"2026-05-18T10:30:00.000Z","type":"session_progress","session_id":"sA","repo":"/work/x","branch":"main","duration_ms":1800000,"turn_count":3,"output_tokens":500}',
+      '{"ts":"2026-05-18T11:00:00.000Z","type":"git_commit","session_id":"sB","repo":"/work/x","branch":"main","commit":"c2","subject":"b"}',
+      '{"ts":"2026-05-18T11:30:00.000Z","type":"session_progress","session_id":"sB","repo":"/work/x","branch":"main","duration_ms":900000,"turn_count":7,"output_tokens":800}',
+    ].join('\n');
+    const drafts = aggregateToDrafts(parseEventsJsonl(lines));
+    expect(drafts).toHaveLength(1);
+    const d = drafts[0];
+    // 1800000 + 900000 = 2700000ms = 45分
+    expect(d.duration).toBe(45);
+    expect(d.meta.turnCount).toBe(10);     // 3 + 7
+    expect(d.meta.outputTokens).toBe(1300); // 500 + 800
+  });
+
+  it('notes に累計ターン数とトークンが表示される', () => {
+    const lines = [
+      '{"ts":"2026-05-18T10:00:00.000Z","type":"git_commit","session_id":"sN","repo":"/work/x","branch":"main","commit":"c1","subject":"feat: x"}',
+      '{"ts":"2026-05-18T10:30:00.000Z","type":"session_progress","session_id":"sN","repo":"/work/x","branch":"main","duration_ms":1800000,"turn_count":42,"input_tokens":100,"output_tokens":9999}',
+    ].join('\n');
+    const drafts = aggregateToDrafts(parseEventsJsonl(lines));
+    expect(drafts[0].notes).toContain('- 累計ターン数: 42');
+    expect(drafts[0].notes).toContain('- 累計トークン: 入力 100 / 出力 9999');
+  });
+});
+
 describe('aggregateToDrafts — duration fallback', () => {
   it('全 session_progress に duration_ms が無い時、firstTs〜lastTs の経過時間で代用する', () => {
     // hook 入力に duration が含まれない実環境の挙動を模擬: progress イベントの duration_ms 抜き

--- a/src/tests/unit/import.test.ts
+++ b/src/tests/unit/import.test.ts
@@ -201,6 +201,31 @@ describe('aggregateToDrafts — groupBy: branch (日付を無視)', () => {
   });
 });
 
+describe('aggregateToDrafts — duration fallback', () => {
+  it('全 session_progress に duration_ms が無い時、firstTs〜lastTs の経過時間で代用する', () => {
+    // hook 入力に duration が含まれない実環境の挙動を模擬: progress イベントの duration_ms 抜き
+    const lines = [
+      '{"ts":"2026-05-18T10:00:00.000Z","type":"session_start","session_id":"sX","repo":"/work/x","branch":"main"}',
+      '{"ts":"2026-05-18T10:30:00.000Z","type":"git_commit","session_id":"sX","repo":"/work/x","branch":"main","commit":"c1","subject":"feat: x"}',
+      '{"ts":"2026-05-18T12:00:00.000Z","type":"session_progress","session_id":"sX","repo":"/work/x","branch":"main"}', // duration_ms 無し
+    ].join('\n');
+    const drafts = aggregateToDrafts(parseEventsJsonl(lines));
+    expect(drafts).toHaveLength(1);
+    // firstTs=10:00, lastTs=12:00 → 120分
+    expect(drafts[0].duration).toBe(120);
+  });
+
+  it('一部のセッションだけ duration_ms があるなら fallback せず合算', () => {
+    const lines = [
+      '{"ts":"2026-05-18T10:00:00.000Z","type":"git_commit","session_id":"sA","repo":"/work/x","branch":"main","commit":"c1","subject":"feat"}',
+      '{"ts":"2026-05-18T11:00:00.000Z","type":"session_progress","session_id":"sA","repo":"/work/x","branch":"main","duration_ms":600000}', // 10min
+    ].join('\n');
+    const drafts = aggregateToDrafts(parseEventsJsonl(lines));
+    // hasDuration が true なので fallback は使わない: 600000ms = 10min
+    expect(drafts[0].duration).toBe(10);
+  });
+});
+
 describe('aggregateToDrafts — gapHours オプション', () => {
   it('gap = 0.5h なら Day1 insightlog 内の 10:30→ なし、Day2 09:00→9:45 は同一バケット内', () => {
     // gapHours 適用は同一バケット内（branch-day）でも更に分割される

--- a/src/tests/unit/import.test.ts
+++ b/src/tests/unit/import.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { parseEventsJsonl, aggregateToDrafts, repoNameOf } from '@/lib/import';
+
+const sampleJsonl = [
+  // Day 1 - InsightLog feat/x: 2 commits, 1 session, 30min, $0.5
+  '{"ts":"2026-05-18T10:00:00.000Z","type":"session_start","session_id":"s1","cwd":"/work/insightlog","repo":"/work/insightlog","repo_remote":"https://github.com/arkatom/InsightLog.git","branch":"feat/x"}',
+  '{"ts":"2026-05-18T10:05:00.000Z","type":"git_commit","session_id":"s1","repo":"/work/insightlog","branch":"feat/x","commit":"a1","subject":"feat: add foo","files":3}',
+  '{"ts":"2026-05-18T10:15:00.000Z","type":"git_commit","session_id":"s1","repo":"/work/insightlog","branch":"feat/x","commit":"a2","subject":"feat: add foo","files":1}',
+  '{"ts":"2026-05-18T10:20:00.000Z","type":"git_commit","session_id":"s1","repo":"/work/insightlog","branch":"feat/x","commit":"a3","subject":"fix: typo","files":1}',
+  '{"ts":"2026-05-18T10:30:00.000Z","type":"session_progress","session_id":"s1","repo":"/work/insightlog","branch":"feat/x","duration_ms":1800000,"cost_usd":0.5}',
+  // Day 1 - other-repo feat/y: 1 commit, 1 session, 15min
+  '{"ts":"2026-05-18T11:00:00.000Z","type":"session_start","session_id":"s2","cwd":"/work/other","repo":"/work/other","branch":"feat/y"}',
+  '{"ts":"2026-05-18T11:08:00.000Z","type":"git_commit","session_id":"s2","repo":"/work/other","branch":"feat/y","commit":"b1","subject":"docs: README update","files":2}',
+  '{"ts":"2026-05-18T11:15:00.000Z","type":"session_progress","session_id":"s2","repo":"/work/other","branch":"feat/y","duration_ms":900000,"cost_usd":0.2}',
+  // 壊れた行 (should be skipped silently)
+  '{this is not json}',
+  '',
+  // 不明 type (should be skipped)
+  '{"ts":"2026-05-18T12:00:00.000Z","type":"unknown_thing","session_id":"sX"}',
+  // Day 2 - InsightLog feat/x: 1 commit (continuing the same branch)
+  '{"ts":"2026-05-19T09:00:00.000Z","type":"session_start","session_id":"s3","repo":"/work/insightlog","branch":"feat/x"}',
+  '{"ts":"2026-05-19T09:30:00.000Z","type":"git_commit","session_id":"s3","repo":"/work/insightlog","branch":"feat/x","commit":"a4","subject":"refactor: extract helper","files":2}',
+  '{"ts":"2026-05-19T09:45:00.000Z","type":"session_progress","session_id":"s3","repo":"/work/insightlog","branch":"feat/x","duration_ms":2700000,"cost_usd":0.3}',
+  // セッションだけ開いて commit 無し（タスク化されない想定）
+  '{"ts":"2026-05-19T13:00:00.000Z","type":"session_start","session_id":"s4","repo":"/work/insightlog","branch":"chore/nothing"}',
+  '{"ts":"2026-05-19T13:05:00.000Z","type":"session_progress","session_id":"s4","repo":"/work/insightlog","branch":"chore/nothing","duration_ms":300000}',
+].join('\n');
+
+describe('parseEventsJsonl', () => {
+  it('正常な行のみを取り込み、壊れた行と未知の type を捨てる', () => {
+    const events = parseEventsJsonl(sampleJsonl);
+    // 期待: session_start * 4 + git_commit * 5 + session_progress * 4 = 13
+    expect(events).toHaveLength(13);
+    expect(events.every((e) => 'ts' in e && 'type' in e && 'session_id' in e)).toBe(true);
+  });
+
+  it('空文字列なら空配列を返す', () => {
+    expect(parseEventsJsonl('')).toEqual([]);
+  });
+
+  it('全行が壊れていても落ちない', () => {
+    expect(parseEventsJsonl('not json\nstill not json')).toEqual([]);
+  });
+});
+
+describe('repoNameOf', () => {
+  it('絶対パスの basename を返す', () => {
+    expect(repoNameOf('/work/insightlog')).toBe('insightlog');
+    expect(repoNameOf('/home/user/projects/foo')).toBe('foo');
+  });
+
+  it('undefined を渡したら undefined', () => {
+    expect(repoNameOf(undefined)).toBeUndefined();
+  });
+});
+
+describe('aggregateToDrafts', () => {
+  it('repo × branch で 2 つの下書きを生成する（commit のないバケットは除外）', () => {
+    const events = parseEventsJsonl(sampleJsonl);
+    const drafts = aggregateToDrafts(events);
+    expect(drafts).toHaveLength(2);
+
+    const insightlog = drafts.find((d) => d.meta.repoName === 'insightlog');
+    const other = drafts.find((d) => d.meta.repoName === 'other');
+    expect(insightlog).toBeDefined();
+    expect(other).toBeDefined();
+  });
+
+  it('日付昇順で並ぶ', () => {
+    const drafts = aggregateToDrafts(parseEventsJsonl(sampleJsonl));
+    expect(drafts[0].meta.firstTs <= drafts[1].meta.firstTs).toBe(true);
+  });
+
+  it('セッション最終 session_progress の duration を合算する（重複コミット subject は dedupe）', () => {
+    const drafts = aggregateToDrafts(parseEventsJsonl(sampleJsonl));
+    const insightlog = drafts.find((d) => d.meta.repoName === 'insightlog')!;
+    // s1: 1800000ms (30min) + s3: 2700000ms (45min) = 4500000ms (75min)
+    expect(insightlog.duration).toBe(75);
+    // commit a1 と a2 は同じ subject "feat: add foo" → 1回だけ。a3=fix, a4=refactor とで合計 3 unique
+    expect(insightlog.notes).toContain('- feat: add foo');
+    expect(insightlog.notes).toContain('- fix: typo');
+    expect(insightlog.notes).toContain('- refactor: extract helper');
+    // 合計 4 commits（dedupe 前）
+    expect(insightlog.meta.commitCount).toBe(4);
+  });
+
+  it('name はユニーク化された最初の subject', () => {
+    const drafts = aggregateToDrafts(parseEventsJsonl(sampleJsonl));
+    const insightlog = drafts.find((d) => d.meta.repoName === 'insightlog')!;
+    expect(insightlog.name).toBe('feat: add foo');
+  });
+
+  it('conventional commits プレフィックスからカテゴリを推測', () => {
+    const drafts = aggregateToDrafts(parseEventsJsonl(sampleJsonl));
+    const insightlog = drafts.find((d) => d.meta.repoName === 'insightlog')!;
+    // feat: + fix: + refactor: が含まれる
+    expect(insightlog.category).toEqual(
+      expect.arrayContaining(['機能開発', 'バグ修正', 'リファクタ'])
+    );
+  });
+
+  it('cost_usd を合算してメタに含める', () => {
+    const drafts = aggregateToDrafts(parseEventsJsonl(sampleJsonl));
+    const insightlog = drafts.find((d) => d.meta.repoName === 'insightlog')!;
+    // s1: 0.5 + s3: 0.3 = 0.8
+    expect(insightlog.meta.costUsd).toBeCloseTo(0.8, 5);
+  });
+
+  it('期間フィルタ since/until で範囲を絞れる', () => {
+    const events = parseEventsJsonl(sampleJsonl);
+    const dayOne = aggregateToDrafts(events, { since: '2026-05-18', until: '2026-05-18' });
+    // Day 1 だけだと insightlog/feat/x にも other-repo/feat/y にも commit がある
+    expect(dayOne).toHaveLength(2);
+    const insightlog = dayOne.find((d) => d.meta.repoName === 'insightlog')!;
+    // s3 を含まないので duration は s1 のみ = 30分
+    expect(insightlog.duration).toBe(30);
+  });
+
+  it('repoFilter で repo を絞れる', () => {
+    const events = parseEventsJsonl(sampleJsonl);
+    const onlyOther = aggregateToDrafts(events, { repoFilter: ['/work/other'] });
+    expect(onlyOther).toHaveLength(1);
+    expect(onlyOther[0].meta.repoName).toBe('other');
+  });
+
+  it('commit が 0 件のバケット (chore/nothing) は除外される', () => {
+    const drafts = aggregateToDrafts(parseEventsJsonl(sampleJsonl));
+    expect(drafts.find((d) => d.meta.branch === 'chore/nothing')).toBeUndefined();
+  });
+
+  it('空のイベント配列なら空の下書き配列', () => {
+    expect(aggregateToDrafts([])).toEqual([]);
+  });
+
+  it('セッション数とコミット数のメタが正しい', () => {
+    const drafts = aggregateToDrafts(parseEventsJsonl(sampleJsonl));
+    const insightlog = drafts.find((d) => d.meta.repoName === 'insightlog')!;
+    expect(insightlog.meta.sessionIds.sort()).toEqual(['s1', 's3']);
+    expect(insightlog.meta.commitCount).toBe(4);
+  });
+});

--- a/src/tests/unit/import.test.ts
+++ b/src/tests/unit/import.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { parseEventsJsonl, aggregateToDrafts, repoNameOf, tsToJstDate } from '@/lib/import';
+import {
+  parseEventsJsonl,
+  aggregateToDrafts,
+  repoNameOf,
+  tsToJstDate,
+  eventsByDraftKey,
+} from '@/lib/import';
 
 // テストデータ: 全 ts は ISO 8601 UTC。JST 換算で確認しやすい時刻を選んでいる。
 // 注意: 2026-05-18T10:00Z = 2026-05-18 19:00 JST → JST 日付 2026-05-18
@@ -270,6 +276,59 @@ describe('aggregateToDrafts — duration fallback', () => {
     const drafts = aggregateToDrafts(parseEventsJsonl(lines));
     // hasDuration が true なので fallback は使わない: 600000ms = 10min
     expect(drafts[0].duration).toBe(10);
+  });
+});
+
+describe('eventsByDraftKey', () => {
+  it('各イベントを所属 draft の draftKey にマップする', () => {
+    const events = parseEventsJsonl(sampleJsonl);
+    const drafts = aggregateToDrafts(events);
+    const map = eventsByDraftKey(events);
+    // sampleJsonl は 3 つの draft を作る (insightlog/feat/x Day1, other/feat/y Day1, insightlog/feat/x Day2)
+    // chore/nothing は commit 無しで除外。git_push/git_checkout は無いので、それ以外のイベントは全部 map に入る
+    const draftKeys = new Set(drafts.map((d) => d.draftKey));
+    for (const [, k] of map) {
+      expect(draftKeys.has(k)).toBe(true);
+    }
+    // chore/nothing 関連 (session_start s4 / session_progress s4) は map に入らない
+    const s4Events = events.filter((e) => e.session_id === 's4');
+    for (const e of s4Events) {
+      expect(map.has(e)).toBe(false);
+    }
+  });
+
+  it('repo/branch/jstDate と ts 範囲が一致するときのみマップされる', () => {
+    const events = parseEventsJsonl(sampleJsonl);
+    const drafts = aggregateToDrafts(events);
+    const day1Insightlog = drafts.find(
+      (d) => d.meta.repoName === 'insightlog' && d.meta.jstDate === '2026-05-18'
+    )!;
+    const day2Insightlog = drafts.find(
+      (d) => d.meta.repoName === 'insightlog' && d.meta.jstDate === '2026-05-19'
+    )!;
+
+    const map = eventsByDraftKey(events);
+
+    // s1 系イベント (Day1) は day1Insightlog にマップ
+    const s1Commits = events.filter((e) => e.session_id === 's1' && e.type === 'git_commit');
+    for (const e of s1Commits) {
+      expect(map.get(e)).toBe(day1Insightlog.draftKey);
+    }
+    // s3 系 (Day2) は day2Insightlog にマップ
+    const s3Commits = events.filter((e) => e.session_id === 's3' && e.type === 'git_commit');
+    for (const e of s3Commits) {
+      expect(map.get(e)).toBe(day2Insightlog.draftKey);
+    }
+  });
+
+  it('groupBy: branch の場合、複数日のイベントが 1 つの draftKey にまとまる', () => {
+    const events = parseEventsJsonl(sampleJsonl);
+    const map = eventsByDraftKey(events, { groupBy: 'branch' });
+    const insightlogCommits = events.filter(
+      (e) => e.repo === '/work/insightlog' && e.type === 'git_commit' && e.branch === 'feat/x'
+    );
+    const keys = new Set(insightlogCommits.map((e) => map.get(e)));
+    expect(keys.size).toBe(1); // 全部同じ draftKey
   });
 });
 

--- a/src/types/import.ts
+++ b/src/types/import.ts
@@ -9,6 +9,7 @@ import type { Task } from './task';
 export type AutologEvent =
   | SessionStartEvent
   | SessionProgressEvent
+  | SessionEndEvent
   | GitCommitEvent
   | GitPushEvent
   | GitCheckoutEvent;
@@ -31,9 +32,29 @@ export interface SessionStartEvent extends AutologEventBase {
 export interface SessionProgressEvent extends AutologEventBase {
   type: 'session_progress';
   duration_ms?: number;
+  /** assistant メッセージ数（≒ ターン数） */
+  turn_count?: number;
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+  /** 旧スキーマ互換用（現在は出力しない） */
   cost_usd?: number;
   lines_added?: number;
   lines_removed?: number;
+}
+
+export interface SessionEndEvent extends AutologEventBase {
+  type: 'session_end';
+  end_reason?: string;
+  duration_ms?: number;
+  turn_count?: number;
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+  /** 旧スキーマ互換（hooks では現状出力しないが、外部ツールが渡してくる可能性に備える） */
+  cost_usd?: number;
 }
 
 export interface GitCommitEvent extends AutologEventBase {
@@ -78,7 +99,15 @@ export type DraftTask = Pick<
     commitCount: number;
     firstTs: string;
     lastTs: string;
+    /** 旧スキーマ互換: hooks 側で計算していた累計コスト */
     costUsd?: number;
+    /** transcript ベースで集計したセッション総ターン数 */
+    turnCount?: number;
+    /** 累計トークン使用量 */
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheReadInputTokens?: number;
+    cacheCreationInputTokens?: number;
   };
 };
 

--- a/src/types/import.ts
+++ b/src/types/import.ts
@@ -1,0 +1,89 @@
+// Claude Code hooks の autolog 出力を取り込むときに使う型
+
+import type { Task } from './task';
+
+/**
+ * events.jsonl の 1 行。type ごとにフィールドが違うので Union 型で表現。
+ * hooks 側で省略されるフィールドは optional。
+ */
+export type AutologEvent =
+  | SessionStartEvent
+  | SessionProgressEvent
+  | GitCommitEvent
+  | GitPushEvent
+  | GitCheckoutEvent;
+
+interface AutologEventBase {
+  ts: string;          // ISO 8601 UTC
+  session_id: string;
+  cwd?: string;
+  repo?: string;       // git toplevel
+  repo_remote?: string;
+  branch?: string;
+}
+
+export interface SessionStartEvent extends AutologEventBase {
+  type: 'session_start';
+  head_sha?: string;
+  source?: 'startup' | 'resume' | 'clear' | 'compact' | string;
+}
+
+export interface SessionProgressEvent extends AutologEventBase {
+  type: 'session_progress';
+  duration_ms?: number;
+  cost_usd?: number;
+  lines_added?: number;
+  lines_removed?: number;
+}
+
+export interface GitCommitEvent extends AutologEventBase {
+  type: 'git_commit';
+  commit?: string;
+  subject?: string;
+  files?: number;
+}
+
+export interface GitPushEvent extends AutologEventBase {
+  type: 'git_push';
+  command?: string;
+}
+
+export interface GitCheckoutEvent extends AutologEventBase {
+  type: 'git_checkout';
+  to_branch?: string;
+  from_branch?: string;
+  command?: string;
+}
+
+/**
+ * インポート時に TaskForm へ渡す下書き。
+ * - `name` / `duration` などは events から推定済み
+ * - `aiToolsUsed` / `timeMinutesNoAi` はユーザー入力で埋める前提（draft mode の必須）
+ * - `category` は推定値があれば候補として渡す（空でも可）
+ */
+export type DraftTask = Pick<
+  Task,
+  'name' | 'taskUrl' | 'duration' | 'reworkCount' | 'category' | 'notes'
+> & {
+  /** 下書きを一意に識別するキー。インポート画面内の選択管理用。 */
+  draftKey: string;
+  /** インポート由来のメタ情報（UI 表示用、Task には保存しない） */
+  meta: {
+    repo?: string;
+    repoName?: string;
+    branch?: string;
+    sessionIds: string[];
+    commitCount: number;
+    firstTs: string;
+    lastTs: string;
+    costUsd?: number;
+  };
+};
+
+export interface AggregateOptions {
+  /** 日付範囲フィルタ（ISO 8601 文字列、UTC）。未指定なら全件。 */
+  since?: string;
+  until?: string;
+  /** repo を絞り込む。指定すると一致しないイベントは除外。 */
+  repoFilter?: string[];
+}

--- a/src/types/import.ts
+++ b/src/types/import.ts
@@ -65,13 +65,15 @@ export type DraftTask = Pick<
   Task,
   'name' | 'taskUrl' | 'duration' | 'reworkCount' | 'category' | 'notes'
 > & {
-  /** 下書きを一意に識別するキー。インポート画面内の選択管理用。 */
+  /** 下書きを一意に識別するキー。インポート画面内の選択管理用 & 取り込み済み判定に使う。 */
   draftKey: string;
   /** インポート由来のメタ情報（UI 表示用、Task には保存しない） */
   meta: {
     repo?: string;
     repoName?: string;
     branch?: string;
+    /** JST 日付（YYYY-MM-DD）。groupBy: 'branch-day' の時に入る */
+    jstDate?: string;
     sessionIds: string[];
     commitCount: number;
     firstTs: string;
@@ -81,9 +83,20 @@ export type DraftTask = Pick<
 };
 
 export interface AggregateOptions {
-  /** 日付範囲フィルタ（ISO 8601 文字列、UTC）。未指定なら全件。 */
+  /** 日付範囲フィルタ（YYYY-MM-DD, JST 解釈）。未指定なら全件。 */
   since?: string;
   until?: string;
   /** repo を絞り込む。指定すると一致しないイベントは除外。 */
   repoFilter?: string[];
+  /**
+   * グルーピング方針。
+   * - `'branch-day'` (デフォルト): repo × branch × JST 日付ごとに 1 下書き。1日1回まとめる運用と相性が良い
+   * - `'branch'`: repo × branch だけでまとめる。複数日に跨ぐ連続作業を1つにしたい時
+   */
+  groupBy?: 'branch' | 'branch-day';
+  /**
+   * 同一バケット内で連続するイベント間のギャップが gapHours を超えたら別の下書きに分割する。
+   * 指定なしなら分割しない。例: 3 で「3 時間以上空いたら別タスク」
+   */
+  gapHours?: number;
 }


### PR DESCRIPTION
## 背景

社内チームから「ログ記録のタイミングが不明確」「複数課題を並行する時の記録工数が大きい」「git commit から自動で雛形が出ると運用負荷が下がる」という要望（Slack より）。これに応える形で、**Claude Code の hooks をタイムカードとして使い、events.jsonl を InsightLog に取り込む** 仕組みを実装した。

## できること

### 1. Claude Code hooks による自動記録（`.claude/hooks/autolog-*.sh`）

- `SessionStart` / `Stop` / `SessionEnd` / `PostToolUse(Bash)` をフック
- セッションの開始・終了、ターン末の累積メトリクス、git の commit/push/checkout/switch を JSONL に追記
- セッション累計の duration / トークン使用量は **transcript ファイルを jq で集計** して取得（Claude Code は Stop hook 入力に累計値を含めないため）
- 出力先は **`\$HOME/.claude/tmp/autolog/events.jsonl`** に集約（リポジトリ横断対応、`INSIGHTLOG_AUTOLOG_DIR` で上書き可）
- 全イベントに `repo` / `repo_remote` / `branch` を付与し、`cd /other && git ...` のような複合コマンドにも追従

### 2. InsightLog 取り込み UI（ヘッダーの Upload ボタン → ImportModal）

- events.jsonl をブラウザで読み込み、**`(repo, branch, JST 日付)` 単位で下書きタスクに集約**
  - グルーピング方針は `groupBy` オプション（デフォルト `branch-day`、`branch` で日付無視）
  - `gapHours` オプションで「同一ブランチ内で N 時間空いたら別タスク」も可能
- 下書きカードクリック → TaskForm の **下書きモード**（name/duration/notes 事前埋め、必須は AI ツール + AI なし所要時間のみ）
- 取り込み済みは **IndexedDB に永続記録** + Chromium 系では **events.jsonl から物理削除**（File System Access API）
- File handle を IndexedDB に永続化して **「前回のファイルから再読込」をワンクリック化**
- Firefox / Safari は IndexedDB seen-set のフォールバックで重複防止

### 3. 既存タスクの編集機能

- TaskItem に鉛筆アイコン
- TaskForm に `initialTask` prop を追加して edit mode を導入

### 4. ログサイズ削減（2 層）

| 層 | 仕組み | 制約 |
|---|---|---|
| ブラウザ取り込み時 | 確定したドラフトに紐づくイベントを物理削除（race-safe で新規追記分を保全） | Chromium 系のみ |
| `autolog-compact.sh` | `session_progress` を session_id ごとに最新 1 行に圧縮 | 手動実行 |

### 5. 日次レポート（`autolog-daily-report.sh`）

- repo × branch × 日次でグルーピングした Markdown サマリーを標準出力
- `--since` / `--until` での範囲指定可
- 1日1回手入力でまとめる運用時のリファレンス

## 検証

- TypeScript: エラーなし
- Vitest: 60/60 通過（新規追加: import.test.ts +24 / autologMaintenance.test.ts 5）
- \`npm run build\`: 成功（ImportModal chunk 5.61 kB gzipped）
- hooks: 実 transcript と合成データで動作確認

## コミット履歴（16 件）

1. **Hooks 基盤**: `b63f44e` → `41fc5e1`（4 commits）
2. **InsightLog 取り込み（Phase 1）**: `1a42e62` → `f7d990c`（3 commits）
3. **JST 日次分割 / IndexedDB / FS Access / 編集**: `3d232db` → `372356f`（4 commits）
4. **正確な duration 取得（transcript ベース）**: `e1cc741` → `c542215`（3 commits）
5. **ログサイズ削減**: `d2579b0` → `f2a282b`（2 commits）

## Test plan

- [ ] ブラウザで InsightLog を開いて、ヘッダーの \"autolog インポート\" ボタンが出る
- [ ] events.jsonl を選択 → 下書き一覧が表示される
- [ ] 下書きをクリック → TaskForm が下書きモードで開き、初期値が事前埋めされている
- [ ] AI ツール / AI なし所要時間を入力 → 保存 → タスク一覧で確認できる
- [ ] 同じ events.jsonl を再インポートしても取り込み済みは候補に出ない（Chromium ならファイル側からも消えている）
- [ ] TaskList で鉛筆ボタン → 編集モードで開き、変更を保存できる
- [ ] hooks が稼働している状態で git commit すると events.jsonl に行が増える

## 既知の制約

- macOS / Windows ネイティブシェルでの動作は **未検証**（Linux Codespace 環境で開発・検証）。bash + jq + GNU date 前提なので、macOS では date 系の epoch ms 計算が動かない可能性あり（transcript 経由の集計には影響、import.ts 側の firstTs/lastTs フォールバックでカバー）
- File System Access API は Chromium 系のみ。Firefox / Safari ではログ物理削除なし
- Claude Code 起動中の作業しか測れない（エディタだけの作業時間は別途必要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)